### PR TITLE
Add bespoke redshift cut functions

### DIFF
--- a/ytree/arbor/arbor.py
+++ b/ytree/arbor/arbor.py
@@ -501,6 +501,38 @@ class Arbor(object):
         pbar.finish()
         return np.array(halos)
 
+    def select_before(self, redshift = 0.0, inclusive = True, fields = None):
+        r"""
+        Select all halos based after a specified redshift.  The inclusivity of
+        the cut is specified by a boolean.
+        """
+        return self._select_redshift(redshift, False, inclusive, fields)
+
+    def select_after(self, redshift = 0.0, inclusive = True, fields = None):
+        r"""
+        Select all halos based before a specified redshift.  The inclusivity of
+        the cut is specified by a boolean.
+        """
+        return self._select_redshift(redshift, True, inclusive, fields)
+
+    def _select_redshift(self, redshift = 0.0, less_than = True,
+                         inclusive = True, fields = None):
+        # We do some input validation here so that we can use our string for
+        # selecting the redshift.
+        if fields is None:
+            fields = ["redshift"]
+        try:
+            '{:f}'.format(redshift)
+        except (TypeError, ValueError):
+            # Can't turn it into a float
+            raise RuntimeError
+        my_halos = self.select_halos(
+            'tree["tree", "redshift"] {0:s}{1} {2:f}'.format(
+                {True: '<', False: '>'}.get(less_than, '<'),
+                {True: '=', False: ''}.get(inclusive, '='), redshift),
+                fields=fields)
+        return my_halos
+
     def add_analysis_field(self, name, units):
         r"""
         Add an empty field to be filled by analysis operations.

--- a/ytree/utilities/testing.py
+++ b/ytree/utilities/testing.py
@@ -14,6 +14,7 @@ testing utilities
 #-----------------------------------------------------------------------------
 
 import h5py
+import numpy as np
 from numpy.testing import \
     assert_array_equal
 import os
@@ -97,6 +98,16 @@ class ArborTest(object):
 
     def test_save_and_reload(self):
         save_and_compare(self.arbor)
+
+    def test_select_redshift(self):
+        v1 = self.arbor.select_before(1.0, inclusive = False)
+        assert all( _["redshift"] > 1.0 for _ in v1)
+        v2 = self.arbor.select_before(1.0, inclusive = True)
+        assert all( _["redshift"] >= 1.0 for _ in v2)
+        v3 = self.arbor.select_after(1.0, inclusive = False)
+        assert all( _["redshift"] < 1.0 for _ in v3)
+        v4 = self.arbor.select_after(1.0, inclusive = True)
+        assert all( _["redshift"] <= 1.0 for _ in v4)
 
 def save_and_compare(arbor):
     """


### PR DESCRIPTION
<!--Thanks for issuing a PR! To help us review, please provide a
description below. Please see the development guide at
http://ytree.readthedocs.io/en/latest/Developing.html for tips.-->

<!--If possible, please issue your PR from a new branch that is
not the master branch.-->


This adds a set of functions that allow easy querying of before/after a
given redshift.  It calls into a base function but does some input
validation, meaning that these can get called with a degree of safety in
the eval'd code.


<!--Describe the changes. Mention any relevant open issues.
If you need help with anything, let us know!-->


<!--Some, none, or all of these may apply. Remove if unnecessary.-->

- [x] Code passes tests.
- [x] New features are documented with docstrings and narrative docs.
- [x] Tests added for fixed bugs or new features.

<!--Thanks!-->