### PR TITLE
Add missing DOI

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -78,7 +78,8 @@ archivePrefix = {arXiv},
     year = {2000},
     volume = {30},
     number = {11},
-    pages = {1203--1233}
+    pages = {1203--1233},
+    doi = {10.1002/1097-024X(200009)30:11<1203::AID-SPE338>3.0.CO;2-N}
 }
 
 @Book{h5py,


### PR DESCRIPTION
This PR adds a missing DOI to the `paper.bib` file, as suggested here: https://github.com/openjournals/joss-reviews/issues/1853#issuecomment-549803761