### PR TITLE
Remove imports from yt.extern.six.

### DIFF
--- a/ytree/data_structures/arbor.py
+++ b/ytree/data_structures/arbor.py
@@ -20,9 +20,6 @@ import json
 import numpy as np
 import os
 
-from yt.extern.six import \
-    add_metaclass, \
-    string_types
 from yt.frontends.ytdata.utilities import \
     save_as_dataset
 from yt.funcs import \
@@ -71,8 +68,7 @@ class RegisteredArbor(type):
         if arbor_type:
             arbor_registry[arbor_type] = cls
 
-@add_metaclass(RegisteredArbor)
-class Arbor(object):
+class Arbor(object, metaclass=RegisteredArbor):
     """
     Base class for all Arbor classes.
 
@@ -313,7 +309,7 @@ class Arbor(object):
         roots of all trees.
         If given an integer, return a tree from the list of trees.
         """
-        if isinstance(key, string_types):
+        if isinstance(key, str):
             if key in ("tree", "prog"):
                 raise SyntaxError("Argument must be a field or integer.")
             self._root_io.get_fields(self, fields=[key])

--- a/ytree/data_structures/tree_node.py
+++ b/ytree/data_structures/tree_node.py
@@ -16,9 +16,6 @@ TreeNode class and member functions
 import numpy as np
 import weakref
 
-from yt.extern.six import \
-    string_types
-
 from ytree.data_structures.fields import \
     FieldContainer
 
@@ -206,7 +203,7 @@ class TreeNode(object):
             if ftype not in arr_types:
                 raise SyntaxError(
                     "First argument must be one of %s." % str(arr_types))
-            if not isinstance(field, string_types):
+            if not isinstance(field, str):
                 raise SyntaxError("Second argument must be a string.")
 
             self.arbor._node_io.get_fields(self, fields=[field], root_only=False)
@@ -214,7 +211,7 @@ class TreeNode(object):
             return self.root._field_data[field][indices]
 
         else:
-            if not isinstance(key, string_types):
+            if not isinstance(key, str):
                 raise SyntaxError("Single argument must be a string.")
 
             # return the progenitor list or tree nodes in a list

--- a/ytree/frontends/consistent_trees/arbor.py
+++ b/ytree/frontends/consistent_trees/arbor.py
@@ -17,7 +17,7 @@ import numpy as np
 
 from yt.funcs import \
     get_pbar
-from yt.units.yt_array import \
+from yt.data_objects.data_containers import \
     UnitParseError
 
 from ytree.data_structures.arbor import \

--- a/ytree/frontends/lhalotree/arbor.py
+++ b/ytree/frontends/lhalotree/arbor.py
@@ -19,7 +19,7 @@ import glob
 
 from yt.funcs import \
     get_pbar
-from yt.units.yt_array import \
+from yt.data_objects.data_containers import \
     UnitParseError
 
 from ytree.data_structures.arbor import \

--- a/ytree/frontends/lhalotree/utils.py
+++ b/ytree/frontends/lhalotree/utils.py
@@ -17,7 +17,6 @@ import warnings
 import numpy as np
 import os
 import glob
-from yt.extern.six import string_types
 
 
 """Default header data type."""
@@ -60,7 +59,7 @@ def read_header_default(filename):
 
     """
     # Open
-    if isinstance(filename, string_types):
+    if isinstance(filename, str):
         fd = open(filename, 'rb')
         close = True
     else:

--- a/ytree/frontends/rockstar/arbor.py
+++ b/ytree/frontends/rockstar/arbor.py
@@ -15,7 +15,7 @@ RockstarArbor class and member functions
 
 import glob
 
-from yt.units.yt_array import \
+from yt.data_objects.data_containers import \
     UnitParseError
 
 from ytree.data_structures.arbor import \


### PR DESCRIPTION
This removes the remaining imports from `yt.extern.six`, which were removed from yt-4.0. This fixes Issue #44.