### PR TITLE
[bugfix] Use regular expression to detect output fields better.

### DIFF
--- a/ytree/frontends/rockstar/arbor.py
+++ b/ytree/frontends/rockstar/arbor.py
@@ -115,7 +115,7 @@ class RockstarArbor(CatalogArbor):
           [self._data_file_class(f, self) for f in my_files]
 
     def _get_file_index(self, f, prefix, suffix):
-        return int(f[f.find(prefix)+len(prefix)+1:f.rfind(suffix)]),
+        return int(f[f.find(prefix)+len(prefix):f.rfind(suffix)]),
 
     @classmethod
     def _is_valid(self, *args, **kwargs):

--- a/ytree/frontends/rockstar/arbor.py
+++ b/ytree/frontends/rockstar/arbor.py
@@ -100,7 +100,7 @@ class RockstarArbor(CatalogArbor):
         """
         Get all out_*.list files and sort them in reverse order.
         """
-        reg = re.search("_\d+[_\.]", self.filename)
+        reg = re.search(r"_\d+[_\.]", self.filename)
         prefix = self.filename[:reg.start()+1]
         suffix = self.filename[reg.end()-1:]
         my_files = glob.glob(
@@ -125,7 +125,7 @@ class RockstarArbor(CatalogArbor):
         fn = args[0]
         if not fn.endswith(".list"):
             return False
-        reg = re.search("_\d+[_\.]", fn)
+        reg = re.search(r"_\d+[_\.]", fn)
         if reg is None:
             return False
         return True

--- a/ytree/frontends/rockstar/arbor.py
+++ b/ytree/frontends/rockstar/arbor.py
@@ -14,6 +14,7 @@ RockstarArbor class and member functions
 #-----------------------------------------------------------------------------
 
 import glob
+import re
 
 from yt.units.yt_array import \
     UnitParseError
@@ -32,7 +33,6 @@ class RockstarArbor(CatalogArbor):
     Use only descendent IDs to determine tree relationship.
     """
 
-    _suffix = ".list"
     _field_info_class = RockstarFieldInfo
     _data_file_class = RockstarDataFile
 
@@ -100,9 +100,12 @@ class RockstarArbor(CatalogArbor):
         """
         Get all out_*.list files and sort them in reverse order.
         """
-        prefix = self.filename.rsplit("_", 1)[0]
-        suffix = self._suffix
-        my_files = glob.glob("%s_*%s" % (prefix, suffix))
+        reg = re.search("_\d+[_\.]", self.filename)
+        prefix = self.filename[:reg.start()+1]
+        suffix = self.filename[reg.end()-1:]
+        my_files = glob.glob(
+            "%s%s%s" % (prefix, "[0-9]"*(reg.end()-reg.start()-2), suffix))
+
         # sort by catalog number
         my_files.sort(
             key=lambda x:
@@ -121,5 +124,8 @@ class RockstarArbor(CatalogArbor):
         """
         fn = args[0]
         if not fn.endswith(".list"):
+            return False
+        reg = re.search("_\d+[_\.]", fn)
+        if reg is None:
             return False
         return True


### PR DESCRIPTION
This fixes the situation where files names `out_000.list` and `out_000_subhalo.list` exist in the same directory. Now, either of these can be loaded.