### PR TITLE
[bugfix] Check if attr is bytes or string.

### DIFF
--- a/ytree/frontends/treefarm/arbor.py
+++ b/ytree/frontends/treefarm/arbor.py
@@ -84,9 +84,10 @@ class TreeFarmArbor(CatalogArbor):
             return False
         try:
             with h5py.File(fn, "r") as f:
-                if "data_type" not in f.attrs:
-                    return False
-                if f.attrs["data_type"].astype(str) != "halo_catalog":
+                dtype = f.attrs.get("data_type")
+                if isinstance(dtype, bytes):
+                    dtype = dtype.astype(str)
+                if dtype != "halo_catalog":
                     return False
         except BaseException:
             return False


### PR DESCRIPTION
Fixes an issue with how ytdata attributes are saved in yt-4.0.