### PR TITLE
save analysis fields to sidecar files

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -18,7 +18,9 @@ to ytree, such as testing and adding support for new file formats, see
 the `ytree Developer Guide
 <http://ytree.readthedocs.io/en/latest/Developing.html>`__.
 
-If you'd like to know more, contact Britton Smith (brittonsmith@gmail.com).
+If you'd like to know more, contact Britton Smith (brittonsmith@gmail.com)
+or come by the #ytree channel on the `yt project Slack
+<https://yt-project.org/slack.html>`__.
 
 You can also find help on the `yt developers list
 <http://lists.spacepope.org/listinfo.cgi/yt-users-spacepope.org>`_.

--- a/doc/source/Arbor.rst
+++ b/doc/source/Arbor.rst
@@ -50,11 +50,10 @@ aliases.  For more information on fields in ``ytree``, see :ref:`fields`.
 How many trees are there?
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-As soon as any information about the collection of trees within the loaded
-dataset is requested, an array will be constructed containing objects
-representing the root of each tree, i.e., the last descendent halo.  This
-structure is accessed by querying the loaded ``Arbor`` directly.  It can
-also be accessed as ``a.trees``.
+The total number of trees in the arbor can be found using the ``size``
+attribute. As soon as any information about the collection of trees within the
+loaded dataset is requested, arrays will be created containing the metadata
+required for generating the root nodes of every tree.
 
 .. code-block:: python
 
@@ -68,7 +67,6 @@ Root Fields
 Field data for all tree roots is accessed by querying the ``Arbor`` in a
 dictionary-like manner.
 
-
 .. code-block:: python
 
    >>> print (a["mass"])
@@ -76,9 +74,8 @@ dictionary-like manner.
    [  6.57410072e+14   5.28489209e+14   5.18129496e+14   4.88920863e+14, ...,
       8.68489209e+11   8.68489209e+11   8.68489209e+11] Msun
 
-``ytree`` uses `yt's system for symbolic units
-<http://yt-project.org/docs/dev/analyzing/units/index.html>`__, allowing for simple
-unit conversion.
+``ytree`` uses the `unyt <https://unyt.readthedocs.io/>`__ package for symbolic units
+on NumPy arrays.
 
 .. code-block:: python
 

--- a/doc/source/Developing.rst
+++ b/doc/source/Developing.rst
@@ -188,7 +188,7 @@ The ``_is_valid`` Function
 
 Within every :class:`~ytree.data_structures.arbor.Arbor` subclass should
 appear a method called ``_is_valid``.  This function is used by
-:func:`~ytree.data_structures.load` to determine if the provide file is
+:func:`~ytree.data_structures.load` to determine if the provided file is
 the correct type.  This function can examine the file's naming convention
 and/or open it and inspect its contents, whatever is required to uniquely
 identify your frontend. Have a look at the various examples.

--- a/doc/source/Examples.rst
+++ b/doc/source/Examples.rst
@@ -88,7 +88,7 @@ significance field.
    >>> my_trees = a[:]
    >>> for tree in my_trees:
            get_significance(tree)
-   >>> a.save_arbor('sig_tree', trees=my_trees)
+   >>> a.save_arbor(filename='sig_tree', trees=my_trees)
 
 Finally, we can load the new data set and use the significance
 field to select the main progenitors.

--- a/doc/source/Fields.rst
+++ b/doc/source/Fields.rst
@@ -158,7 +158,7 @@ initialized to zero.
    [ 0.33919263  0.79557815  0.38264336  0.53073945  0.09634924  0.6035886, ...
      0.9506636   0.9094426   0.85436984  0.66779632  0.58816873] m**2
 
-Analysis fields will be automatically saved when the
+Analysis fields will be saved when the
 :class:`~ytree.data_structures.tree_node.TreeNode` objects that have been
 analyzed are saved with :func:`~ytree.data_structures.arbor.Arbor.save_arbor`
 or :func:`~ytree.data_structures.tree_node.TreeNode.save_tree`.
@@ -166,5 +166,21 @@ or :func:`~ytree.data_structures.tree_node.TreeNode.save_tree`.
 .. code-block:: python
 
    >>> my_trees = a[:] # all trees
-   >>> # do analysis...
+   >>> for my_tree in my_trees:
+   ...     # do analysis...
    >>> a.save_arbor(trees=my_trees)
+
+.. note:: Trees with altered analysis fields must be provided explicitly to
+   :func:`~ytree.data_structures.arbor.Arbor.save_arbor` in order for fields
+   to be saved properly.
+
+Re-saving Analysis Fields
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+All analysis fields are saved to sidecar files with the "-analysis" keyword
+appended to them. They can be altered and the arbor re-saved as many times
+as you like. In the very specific case of re-saving all trees and not
+providing a new filename or custom list of fields (as in the example above),
+analysis fields will be saved in place (i.e., over-writing the "-analysis"
+files). The conventional on-disk fields will not be re-saved as they cannot
+be altered.

--- a/doc/source/api_reference.rst
+++ b/doc/source/api_reference.rst
@@ -42,8 +42,16 @@ Functionality for plotting merger trees.
    ~ytree.visualization.tree_plot.TreePlot
    ~ytree.visualization.tree_plot.TreePlot.save
 
+.. _internal-classes:
+
 Internal Classes
 ----------------
+
+Base Classes
+############
+
+All frontends inherit from these base classes for arbor, fields,
+and i/o.
 
 .. autosummary::
    :toctree: generated/
@@ -58,32 +66,68 @@ Internal Classes
    ~ytree.data_structures.io.DefaultRootFieldIO
    ~ytree.data_structures.io.DataFile
    ~ytree.data_structures.io.CatalogDataFile
+
+Arbor Subclasses
+################
+
+Arbor subclasses for each frontend.
+
+.. autosummary::
+   :toctree: generated/
+
    ~ytree.frontends.ahf.arbor.AHFArbor
-   ~ytree.frontends.ahf.fields.AHFFieldInfo
-   ~ytree.frontends.ahf.io.AHFDataFile
    ~ytree.frontends.consistent_trees.arbor.ConsistentTreesArbor
    ~ytree.frontends.consistent_trees.arbor.ConsistentTreesGroupArbor
    ~ytree.frontends.consistent_trees.arbor.ConsistentTreesHlistArbor
-   ~ytree.frontends.consistent_trees.fields.ConsistentTreesFieldInfo
-   ~ytree.frontends.consistent_trees.io.ConsistentTreesDataFile
-   ~ytree.frontends.consistent_trees.io.ConsistentTreesTreeFieldIO
-   ~ytree.frontends.consistent_trees.io.ConsistentTreesHlistDataFile
    ~ytree.frontends.consistent_trees_hdf5.arbor.ConsistentTreesHDF5Arbor
+   ~ytree.frontends.lhalotree.arbor.LHaloTreeArbor
+   ~ytree.frontends.rockstar.arbor.RockstarArbor
+   ~ytree.frontends.treefarm.arbor.TreeFarmArbor
+   ~ytree.frontends.ytree.arbor.YTreeArbor
+
+FieldInfo Subclasses
+####################
+
+Subclasses for frontend-specific field definitions.
+
+.. autosummary::
+   :toctree: generated/
+
+   ~ytree.frontends.ahf.fields.AHFFieldInfo
+   ~ytree.frontends.consistent_trees.fields.ConsistentTreesFieldInfo
    ~ytree.frontends.consistent_trees_hdf5.fields.ConsistentTreesHDF5FieldInfo
-   ~ytree.frontends.consistent_trees_hdf5.io.ConsistentTreesHDF5DataFile
+   ~ytree.frontends.lhalotree.fields.LHaloTreeFieldInfo
+   ~ytree.frontends.rockstar.fields.RockstarFieldInfo
+   ~ytree.frontends.treefarm.fields.TreeFarmFieldInfo
+
+FieldIO Subclasses
+##################
+
+Subclasses for data i/o from a whole dataset.
+
+.. autosummary::
+   :toctree: generated/
+
+   ~ytree.frontends.ahf.io.AHFDataFile
+   ~ytree.frontends.consistent_trees.io.ConsistentTreesTreeFieldIO
    ~ytree.frontends.consistent_trees_hdf5.io.ConsistentTreesHDF5TreeFieldIO
    ~ytree.frontends.consistent_trees_hdf5.io.ConsistentTreesHDF5RootFieldIO
-   ~ytree.frontends.lhalotree.arbor.LHaloTreeArbor
-   ~ytree.frontends.lhalotree.fields.LHaloTreeFieldInfo
    ~ytree.frontends.lhalotree.io.LHaloTreeTreeFieldIO
    ~ytree.frontends.lhalotree.io.LHaloTreeRootFieldIO
-   ~ytree.frontends.rockstar.arbor.RockstarArbor
-   ~ytree.frontends.rockstar.fields.RockstarFieldInfo
-   ~ytree.frontends.rockstar.io.RockstarDataFile
-   ~ytree.frontends.treefarm.arbor.TreeFarmArbor
-   ~ytree.frontends.treefarm.fields.TreeFarmFieldInfo
-   ~ytree.frontends.treefarm.io.TreeFarmDataFile
-   ~ytree.frontends.ytree.arbor.YTreeArbor
-   ~ytree.frontends.ytree.io.YTreeDataFile
    ~ytree.frontends.ytree.io.YTreeTreeFieldIO
    ~ytree.frontends.ytree.io.YTreeRootFieldIO
+
+DataFile Subclasses
+###################
+
+Subclasses for data i/o from individual files.
+
+.. autosummary::
+   :toctree: generated/
+
+   ~ytree.frontends.consistent_trees.io.ConsistentTreesDataFile
+   ~ytree.frontends.consistent_trees.io.ConsistentTreesHlistDataFile
+   ~ytree.frontends.consistent_trees_hdf5.io.ConsistentTreesHDF5DataFile
+   ~ytree.frontends.rockstar.io.RockstarDataFile
+   ~ytree.frontends.treefarm.io.TreeFarmDataFile
+   ~ytree.frontends.ytree.io.YTreeDataFile

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -21,7 +21,8 @@ from numpy.testing import \
 import os
 
 from ytree.utilities.exceptions import \
-    ArborFieldAlreadyExists
+    ArborFieldAlreadyExists, \
+    ArborUnsettableField
 from ytree.utilities.testing import \
     requires_file, \
     TempDirTest
@@ -106,3 +107,11 @@ class AnalysisFieldTest(TempDirTest):
 
         with assert_raises(ArborFieldAlreadyExists):
             a.add_analysis_field('mass', units='g')
+
+    @requires_file(CT)
+    def test_analysis_unsettable_fields(self):
+        a = ytree.load(CT)
+
+        with assert_raises(ArborUnsettableField):
+            my_tree = a[0]
+            my_tree['mass'] = 50

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -83,7 +83,7 @@ class ExampleTest(TempDirTest):
         for tree in my_trees:
             get_significance(tree)
 
-        fn = a.save_arbor('sig_tree', trees=my_trees)
+        fn = a.save_arbor(filename='sig_tree', trees=my_trees)
         a2 = ytree.load(fn)
         a2.set_selector('max_field_value', 'significance')
         prog = a2[0]['prog']

--- a/ytree/data_structures/arbor.py
+++ b/ytree/data_structures/arbor.py
@@ -820,6 +820,7 @@ class Arbor(metaclass=RegisteredArbor):
 
         self.analysis_field_list.append(name)
         self.field_info[name] = {"type": "analysis",
+                                 "default": default,
                                  "dtype": dtype,
                                  "units": units}
         self._field_data[name] = \

--- a/ytree/data_structures/arbor.py
+++ b/ytree/data_structures/arbor.py
@@ -783,7 +783,7 @@ class Arbor(metaclass=RegisteredArbor):
         pbar.finish()
         return np.array(halos)
 
-    def add_analysis_field(self, name, units, dtype=None):
+    def add_analysis_field(self, name, units, dtype=None, default=0):
         r"""
         Add an empty field to be filled by analysis operations.
 
@@ -797,6 +797,9 @@ class Arbor(metaclass=RegisteredArbor):
             Data type for field values. If None, the default data type
             of the arbor is used.
             Default: None.
+        default: optional, numeric
+            Default field value when field is initialized.
+            Default: 0.
 
         Examples
         --------
@@ -805,7 +808,8 @@ class Arbor(metaclass=RegisteredArbor):
         >>> a = ytree.load("tree_0_0_0.dat")
         >>> a.add_analysis_field("robots", "Msun * kpc")
         >>> # Set field for some halo.
-        >>> a[0]["tree"][7]["robots"] = 1979.816
+        >>> my_tree = a[0]
+        >>> my_tree["tree"][7]["robots"] = 1979.816
         """
 
         if name in self.field_info:
@@ -819,7 +823,7 @@ class Arbor(metaclass=RegisteredArbor):
                                  "dtype": dtype,
                                  "units": units}
         self._field_data[name] = \
-          self.arr(np.zeros(self.size, dtype=dtype), units)
+          self.arr(np.full(self.size, default, dtype=dtype), units)
 
     def add_alias_field(self, alias, field, units=None,
                         force_add=True):
@@ -988,8 +992,7 @@ Check the TypeError exception above for more details.
         """
         return False
 
-    def save_arbor(self, filename="arbor", fields=None, trees=None,
-                   max_file_size=524288):
+    def save_arbor(self, **kwargs):
         r"""
         Save the arbor to a file.
 
@@ -1030,9 +1033,7 @@ Check the TypeError exception above for more details.
 
         """
 
-        fn = save_arbor(self, filename=filename,
-                        fields=fields, trees=trees,
-                        max_file_size=max_file_size)
+        fn = save_arbor(self, **kwargs)
         return fn
 
 class CatalogArbor(Arbor):

--- a/ytree/data_structures/io.py
+++ b/ytree/data_structures/io.py
@@ -172,7 +172,8 @@ class TreeFieldIO(FieldIO):
         fi = self.arbor.field_info[name]
         units = fi.get('units', '')
         dtype = fi.get('dtype', self.default_dtype)
-        data = np.zeros(storage_object.tree_size, dtype=dtype)
+        value = fi.get('default', 0)
+        data = np.full(storage_object.tree_size, value, dtype=dtype)
         if units:
             data = self.arbor.arr(data, units)
         storage_object._field_data[name] = data

--- a/ytree/data_structures/save_arbor.py
+++ b/ytree/data_structures/save_arbor.py
@@ -120,7 +120,13 @@ def determine_field_list(arbor, fields, update):
     if fields in [None, "all"]:
         # If this is an update, don't resave disk fields.
         field_list = arbor.analysis_field_list.copy()
-        if not update:
+
+        # Add in previously saved analysis fields
+        if update:
+            field_list.extend(
+                [field for field in arbor.field_list
+                 if arbor.field_info[field].get("type") == "analysis_saved"])
+        else:
             field_list.extend(arbor.field_list)
 
         # If a field has an alias, get that instead.
@@ -218,7 +224,7 @@ def save_data_file(arbor, filename, fields, tree_group,
     for field, fieldname in zip(fields, fieldnames):
         fi = arbor.field_info[field]
 
-        if fi.get("type") == "analysis":
+        if fi.get("type") in ["analysis", "analysis_saved"]:
             my_fdata  = analysis_fdata
             my_ftypes = analysis_ftypes
         else:
@@ -283,7 +289,7 @@ def save_header_file(arbor, filename, fields, root_field_data,
     for field, fieldname in zip(fields, fieldnames):
         fi = arbor.field_info[field]
 
-        if fi.get("type") == "analysis":
+        if fi.get("type") in ["analysis", "analysis_saved"]:
             my_fi     = analysis_fi
             my_rdata  = analysis_rdata
             my_rtypes = analysis_rtypes

--- a/ytree/data_structures/save_arbor.py
+++ b/ytree/data_structures/save_arbor.py
@@ -170,8 +170,9 @@ def save_data_files(arbor, filename, fields, trees,
         group_nnodes.append(cg_nnodes)
         group_ntrees.append(cg_ntrees)
 
-        total_guess = int(np.round(trees.size * cg_number /
-                                   sum(group_ntrees)))
+        total_guess = \
+          int(np.round(len(list(trees)) * cg_number /
+                       sum(group_ntrees)))
         save_data_file(
             arbor, filename, fields,
             np.array(current_group), root_field_data,

--- a/ytree/data_structures/save_arbor.py
+++ b/ytree/data_structures/save_arbor.py
@@ -170,7 +170,7 @@ def save_data_files(arbor, filename, fields, trees,
         group_nnodes.append(cg_nnodes)
         group_ntrees.append(cg_ntrees)
 
-        total_guess = int(np.round(arbor.size * cg_number /
+        total_guess = int(np.round(trees.size * cg_number /
                                    sum(group_ntrees)))
         save_data_file(
             arbor, filename, fields,

--- a/ytree/data_structures/save_arbor.py
+++ b/ytree/data_structures/save_arbor.py
@@ -14,6 +14,9 @@ from yt.funcs import \
     ensure_dir
 from yt.frontends.ytdata.utilities import \
     save_as_dataset
+from ytree.utilities.logger import \
+    fake_pbar, \
+    ytreeLogger as mylog
 
 #-----------------------------------------------------------------------------
 # Copyright (c) ytree development team. All rights reserved.
@@ -23,7 +26,7 @@ from yt.frontends.ytdata.utilities import \
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-def save_arbor(arbor, filename="arbor", fields=None, trees=None,
+def save_arbor(arbor, filename=None, fields=None, trees=None,
                max_file_size=524288):
     """
     Save the arbor to a file.
@@ -32,8 +35,19 @@ def save_arbor(arbor, filename="arbor", fields=None, trees=None,
     """
 
     arbor._plant_trees()
+    update, filename = determine_save_state(
+        arbor, filename, fields, trees)
     filename = determine_output_filename(filename, ".h5")
-    fields = determine_field_list(arbor, fields)
+    fields = determine_field_list(arbor, fields, update)
+
+    if not fields:
+        mylog.warn(
+            "No action will be taken for the following reasons:\n"
+            " - This dataset is already a YTreeArbor.\n"
+            " - No filename has been given.\n"
+            " - No new analysis fields have been created.\n"
+            " - No custom list of trees has been provided.")
+        return None
 
     group_nnodes, group_ntrees, root_field_data = \
       save_data_files(arbor, filename, fields, trees,
@@ -44,6 +58,30 @@ def save_arbor(arbor, filename="arbor", fields=None, trees=None,
         group_nnodes, group_ntrees)
 
     return header_filename
+
+def determine_save_state(arbor, filename, fields, trees):
+    """
+    Determine if we can just output new analysis fields to
+    sidecar files and skip saving the rest.
+
+    If updating return filenames associated with currently loaded arbor.
+    """
+
+    from ytree.frontends.ytree.arbor import YTreeArbor
+
+    if not isinstance(arbor, YTreeArbor):
+        return False, filename
+
+    if filename is not None:
+        return False, filename
+
+    if fields not in [None, "all"]:
+        return False, filename
+
+    if trees is not None and len(tree) != arbor.size:
+        return False, filename
+
+    return True, arbor.parameter_filename
 
 def determine_tree_list(arbor, trees):
     """
@@ -62,6 +100,9 @@ def determine_output_filename(path, suffix):
     Figure out the output filename.
     """
 
+    if path is None:
+        path = 'arbor'
+
     if path.endswith(suffix):
         dirname = os.path.dirname(path)
         filename = path[:-len(suffix)]
@@ -72,23 +113,28 @@ def determine_output_filename(path, suffix):
     ensure_dir(dirname)
     return filename
 
-def determine_field_list(arbor, fields):
+def determine_field_list(arbor, fields, update):
     """
     Get the list of fields to be saved.
     """
 
     if fields in [None, "all"]:
+        # If this is an update, don't resave disk fields.
+        field_list = arbor.analysis_field_list.copy()
+        if not update:
+            field_list.extend(arbor.field_list)
+
         # If a field has an alias, get that instead.
         fields = []
-        for field in arbor.field_list + arbor.analysis_field_list:
+        for field in field_list:
             fields.extend(
                 arbor.field_info[field].get("aliases", [field]))
+
     else:
         fields.extend([f for f in ["uid", "desc_uid"]
                        if f not in fields])
 
     return fields
-
 
 def get_output_fieldnames(fields):
     """
@@ -155,40 +201,61 @@ def save_data_file(arbor, filename, fields, tree_group,
     """
 
     fieldnames = get_output_fieldnames(fields)
-    ftypes = dict((f, "data") for f in fieldnames)
 
     arbor._node_io_loop(
         arbor._node_io.get_fields,
         pbar="Getting fields [%d / ~%d]" % (current_iteration, total_guess),
         root_nodes=tree_group, fields=fields, root_only=False)
 
-    fdata = {}
+    main_fdata  = {}
+    main_ftypes = {}
+
+    analysis_fdata  = {}
+    analysis_ftypes = {}
+
     my_tree_size  = np.array([tree.tree_size for tree in tree_group])
     my_tree_end   = my_tree_size.cumsum()
     my_tree_start = my_tree_end - my_tree_size
     for field, fieldname in zip(fields, fieldnames):
-        fdata[fieldname] = uconcatenate(
+        fi = arbor.field_info[field]
+
+        if fi.get("type") == "analysis":
+            my_fdata  = analysis_fdata
+            my_ftypes = analysis_ftypes
+        else:
+            my_fdata  = main_fdata
+            my_ftypes = main_ftypes
+
+        my_ftypes[fieldname] = "data"
+        my_fdata[fieldname]  = uconcatenate(
             [node._field_data[field] if node.is_root else node["tree", field]
              for node in tree_group])
-        root_field_data[field].append(fdata[fieldname][my_tree_start])
+        root_field_data[field].append(my_fdata[fieldname][my_tree_start])
 
     # In case we have saved any non-root trees,
     # mark them as having no descendents.
-    fdata['desc_uid'][my_tree_start] = -1
+    if "desc_uid" in main_fdata:
+        main_fdata["desc_uid"][my_tree_start] = -1
 
     for node in tree_group:
         arbor.reset_node(node)
 
-    fdata["tree_start_index"] = my_tree_start
-    fdata["tree_end_index"]   = my_tree_end
-    fdata["tree_size"]        = my_tree_size
-    for ft in ["tree_start_index",
-               "tree_end_index",
-               "tree_size"]:
-        ftypes[ft] = "index"
-    my_filename = "%s_%04d.h5" % (filename, current_iteration-1)
-    save_as_dataset({}, my_filename, fdata,
-                    field_types=ftypes)
+    if main_fdata:
+        main_fdata["tree_start_index"] = my_tree_start
+        main_fdata["tree_end_index"]   = my_tree_end
+        main_fdata["tree_size"]        = my_tree_size
+        for ft in ["tree_start_index",
+                   "tree_end_index",
+                   "tree_size"]:
+            main_ftypes[ft] = "index"
+        my_filename = f"{filename}_{current_iteration-1:04d}.h5"
+        save_as_dataset({}, my_filename, main_fdata,
+                        field_types=main_ftypes)
+
+    if analysis_fdata:
+        my_filename = f"{filename}-analysis_{current_iteration-1:04d}.h5"
+        save_as_dataset({}, my_filename, analysis_fdata,
+                        field_types=analysis_ftypes)
 
 def save_header_file(arbor, filename, fields, root_field_data,
                      group_nnodes, group_ntrees):
@@ -202,45 +269,81 @@ def save_header_file(arbor, filename, fields, root_field_data,
                  "omega_lambda"]:
         if hasattr(arbor, attr):
             ds[attr] = getattr(arbor, attr)
-    extra_attrs = {"box_size": arbor.box_size,
-                   "arbor_type": "YTreeArbor",
-                   "unit_registry_json": arbor.unit_registry.to_json()}
 
-    # write header file
-    myfi = {}
-    rdata = {}
-    rtypes = {}
+    # Data structures for disk fields.
+    main_fi     = {}
+    main_rdata  = {}
+    main_rtypes = {}
+
+    # Analysis fields saved separately.
+    analysis_fi     = {}
+    analysis_rdata  = {}
+    analysis_rtypes = {}
+
     fieldnames = get_output_fieldnames(fields)
     for field, fieldname in zip(fields, fieldnames):
         fi = arbor.field_info[field]
-        myfi[fieldname] = \
+
+        if fi.get("type") == "analysis":
+            my_fi     = analysis_fi
+            my_rdata  = analysis_rdata
+            my_rtypes = analysis_rtypes
+        else:
+            my_fi     = main_fi
+            my_rdata  = main_rdata
+            my_rtypes = main_rtypes
+
+        my_fi[fieldname] = \
           dict((key, fi[key])
                for key in ["units", "description"]
                if key in fi)
-        rdata[fieldname] = uconcatenate(root_field_data[field])
-        rtypes[fieldname] = "data"
+        my_rdata[fieldname] = uconcatenate(root_field_data[field])
+        my_rtypes[fieldname] = "data"
+
     # all saved trees will be roots
-    rdata["desc_uid"][:] = -1
+    if "desc_uid" in main_rdata:
+        main_rdata["desc_uid"][:] = -1
 
-    tree_end_index   = group_ntrees.cumsum()
-    tree_start_index = tree_end_index - group_ntrees
+    # Save the primary fields.
+    header_filename = f"{filename}.h5"
+    if main_fi:
+        tree_end_index   = group_ntrees.cumsum()
+        tree_start_index = tree_end_index - group_ntrees
 
-    extra_attrs["field_info"] = json.dumps(myfi)
-    extra_attrs["total_files"] = group_nnodes.size
-    extra_attrs["total_trees"] = group_ntrees.sum()
-    extra_attrs["total_nodes"] = group_nnodes.sum()
-    hdata = {"tree_start_index": tree_start_index,
-             "tree_end_index"  : tree_end_index,
-             "tree_size"       : group_ntrees}
-    hdata.update(rdata)
-    del rdata
-    htypes = dict((f, "index") for f in hdata)
-    htypes.update(rtypes)
+        extra_attrs = {
+            "box_size": arbor.box_size,
+            "arbor_type": "YTreeArbor",
+            "unit_registry_json": arbor.unit_registry.to_json()}
+        extra_attrs["field_info"] = json.dumps(main_fi)
+        extra_attrs["total_files"] = group_nnodes.size
+        extra_attrs["total_trees"] = group_ntrees.sum()
+        extra_attrs["total_nodes"] = group_nnodes.sum()
+        hdata = {"tree_start_index": tree_start_index,
+                 "tree_end_index"  : tree_end_index,
+                 "tree_size"       : group_ntrees}
+        hdata.update(main_rdata)
+        del main_rdata
+        htypes = dict((f, "index") for f in hdata)
+        htypes.update(main_rtypes)
 
-    header_filename = "%s.h5" % filename
-    save_as_dataset(ds, header_filename, hdata,
-                    field_types=htypes,
-                    extra_attrs=extra_attrs)
-    del hdata
+        save_as_dataset(ds, header_filename, hdata,
+                        field_types=htypes,
+                        extra_attrs=extra_attrs)
+        del hdata
+
+    # Save analysis fields to a sidecar file.
+    if analysis_fi:
+        extra_attrs = {}
+        extra_attrs["field_info"] = json.dumps(analysis_fi)
+        hdata = analysis_rdata
+        del analysis_rdata
+        htypes = dict((f, "index") for f in hdata)
+        htypes.update(analysis_rtypes)
+
+        analysis_header_filename = f"{filename}-analysis.h5"
+        save_as_dataset(ds, analysis_header_filename, hdata,
+                        field_types=htypes,
+                        extra_attrs=extra_attrs)
+        del hdata
 
     return header_filename

--- a/ytree/data_structures/save_arbor.py
+++ b/ytree/data_structures/save_arbor.py
@@ -15,7 +15,6 @@ from yt.funcs import \
 from yt.frontends.ytdata.utilities import \
     save_as_dataset
 from ytree.utilities.logger import \
-    fake_pbar, \
     ytreeLogger as mylog
 
 #-----------------------------------------------------------------------------
@@ -78,7 +77,7 @@ def determine_save_state(arbor, filename, fields, trees):
     if fields not in [None, "all"]:
         return False, filename
 
-    if trees is not None and len(tree) != arbor.size:
+    if trees is not None and len(trees) != arbor.size:
         return False, filename
 
     return True, arbor.parameter_filename

--- a/ytree/data_structures/save_arbor.py
+++ b/ytree/data_structures/save_arbor.py
@@ -258,7 +258,7 @@ def save_data_file(arbor, filename, fields, tree_group,
                         field_types=main_ftypes)
 
     if analysis_fdata:
-        my_filename = f"{filename}-analysis_{current_iteration-1:04d}.h5"
+        my_filename = f"{filename}_{current_iteration-1:04d}-analysis.h5"
         save_as_dataset({}, my_filename, analysis_fdata,
                         field_types=analysis_ftypes)
 

--- a/ytree/data_structures/tree_node.py
+++ b/ytree/data_structures/tree_node.py
@@ -212,7 +212,7 @@ class TreeNode:
             root = self
             tree_id = 0
             # if root, set the value in the arbor field storage
-            self.arbor._field_data[key][self._arbor_index] = value
+            self.arbor[key][self._arbor_index] = value
         else:
             root = self.root
             tree_id = self.tree_id

--- a/ytree/data_structures/tree_node.py
+++ b/ytree/data_structures/tree_node.py
@@ -18,6 +18,8 @@ import weakref
 
 from ytree.data_structures.fields import \
     FieldContainer
+from ytree.utilities.exceptions import \
+    ArborUnsettableField
 
 class TreeNode:
     """
@@ -207,6 +209,10 @@ class TreeNode:
         """
         Set analysis field value for this node.
         """
+
+        ftype = self.arbor.field_info[key].get('type')
+        if ftype not in ['analysis', 'analysis_saved']:
+            raise ArborUnsettableField(key, self.arbor)
 
         if self.is_root:
             root = self

--- a/ytree/frontends/consistent_trees_hdf5/arbor.py
+++ b/ytree/frontends/consistent_trees_hdf5/arbor.py
@@ -57,7 +57,7 @@ _access_names = {
 
 class ConsistentTreesHDF5Arbor(Arbor):
     """
-    Arbors loaded from consistent-trees tree_*.dat files.
+    Arbors loaded from consistent-trees data converted into HDF5.
     """
 
     _parameter_file_is_data_file = True

--- a/ytree/frontends/ytree/arbor.py
+++ b/ytree/frontends/ytree/arbor.py
@@ -127,7 +127,7 @@ class YTreeArbor(Arbor):
         if self.analysis_filename is not None:
             for i, df in enumerate(self.data_files):
                 df.analysis_filename = \
-                  f"{self._prefix}-analysis_{i:04d}{self._suffix}"
+                  f"{self._prefix}_{i:04d}-analysis{self._suffix}"
 
     @classmethod
     def _is_valid(self, *args, **kwargs):

--- a/ytree/frontends/ytree/arbor.py
+++ b/ytree/frontends/ytree/arbor.py
@@ -62,7 +62,7 @@ class YTreeArbor(Arbor):
 
         dfi = np.digitize(ai, self._node_io._ei)
         udfi = np.unique(dfi)
-        data_files = [self._node_io.data_files[i] for i in udfi]
+        data_files = [self.data_files[i] for i in udfi]
         index_list = [io_order[dfi == i] for i in udfi]
 
         return data_files, index_list, return_order

--- a/ytree/frontends/ytree/io.py
+++ b/ytree/frontends/ytree/io.py
@@ -35,8 +35,10 @@ class YTreeDataFile(DataFile):
 
     def close(self):
         self.fh.close()
+        self.fh = None
         if hasattr(self, "analysis_filename"):
             self.analysis_fh.close()
+            self.analysis_fh = None
 
 class YTreeTreeFieldIO(TreeFieldIO):
     def _read_fields(self, root_node, fields, dtypes=None, root_only=False):

--- a/ytree/frontends/ytree/io.py
+++ b/ytree/frontends/ytree/io.py
@@ -29,12 +29,19 @@ class YTreeDataFile(DataFile):
         self._end_index = None
 
     def open(self):
-        self.fh = h5py.File(self.filename, "r")
+        self.fh = h5py.File(self.filename, mode="r")
+        if hasattr(self, "analysis_filename"):
+            self.analysis_fh = h5py.File(self.analysis_filename, mode="r")
+
+    def close(self):
+        self.fh.close()
+        if hasattr(self, "analysis_filename"):
+            self.analysis_fh.close()
 
 class YTreeTreeFieldIO(TreeFieldIO):
     def _read_fields(self, root_node, fields, dtypes=None, root_only=False):
         dfi = np.digitize(root_node._ai, self._ei)
-        data_file = self.data_files[dfi]
+        data_file = self.arbor.data_files[dfi]
 
         if dtypes is None:
             dtypes = {}
@@ -59,14 +66,21 @@ class YTreeTreeFieldIO(TreeFieldIO):
         fi = self.arbor.field_info
         for field in fields:
             if field not in data_file._field_cache:
-                fdata = data_file.fh["data/%s" % field][()]
+                if fi[field].get("type") == "analysis_saved":
+                    fh = data_file.analysis_fh
+                else:
+                    fh = data_file.fh
+                fdata = fh["data/%s" % field][()]
+
                 dtype = dtypes.get(field)
                 if dtype is not None:
                     fdata = fdata.astype(dtype)
+
                 units = fi[field].get("units", "")
                 if units != "":
                     fdata = self.arbor.arr(fdata, units)
                 data_file._field_cache[field] = fdata
+
             field_data[field] = \
               data_file._field_cache[field][
                   data_file._start_index[ii]:data_file._end_index[ii]]
@@ -81,11 +95,18 @@ class YTreeRootFieldIO(DefaultRootFieldIO):
         if dtypes is None:
             dtypes = {}
 
-        fh = h5py.File(self.arbor.filename, "r")
+        fh = h5py.File(self.arbor.filename, mode="r")
+        if self.arbor.analysis_filename is not None:
+            analysis_fh = h5py.File(self.arbor.analysis_filename, mode="r")
+
         field_data = {}
         fi = self.arbor.field_info
         for field in fields:
-            data = fh["data/%s" % field][()]
+            if fi[field].get("type") == "analysis_saved":
+                my_fh = analysis_fh
+            else:
+                my_fh = fh
+            data = my_fh["data/%s" % field][()]
             dtype = dtypes.get(field)
             if dtype is not None:
                 data = data.astype(dtype)
@@ -93,6 +114,9 @@ class YTreeRootFieldIO(DefaultRootFieldIO):
             if units != "":
                 data = self.arbor.arr(data, units)
             field_data[field] = data
+
         fh.close()
+        if self.arbor.analysis_filename is not None:
+            analysis_fh.close()
 
         return field_data

--- a/ytree/utilities/exceptions.py
+++ b/ytree/utilities/exceptions.py
@@ -62,3 +62,9 @@ class ArborAnalysisFieldNotFound(ArborFieldException):
         return ("Analysis field \"%s\" has been removed "
                 "from arbor field storage in %s.") % \
           (self.field, self.arbor)
+
+class ArborUnsettableField(ArborFieldException):
+    def __str__(self):
+        return ("Cannot set values for field \"%s\" in %s. "
+                "Only analysis fields can be set.") % \
+          (self.field, self.arbor)


### PR DESCRIPTION
<!--Thanks for issuing a PR! To help us review, please provide a
description below. Please see the development guide at
http://ytree.readthedocs.io/en/latest/Developing.html for tips.-->

<!--If possible, please issue your PR from a new branch that is
not the master branch.-->

## PR Summary

This allows all analysis fields to be saved in sidecar data files and for the on-disk fields not to be rewritten if all we want to do is save new analysis fields. If you are already working from a re-saved dataset (from `Arbor.save_arbor`) and you call `save_arbor` after creating new analysis fields, only the new fields will be written if the following conditions are met:
- the default field list (`fields=None`) is provided
- the default filename is given (`filename=None`)
- the number of trees to be saved is the same as the total number in the dataset

<!--Describe the changes. Mention any relevant open issues.
If you need help with anything, let us know!-->

## PR Checklist

<!--Some, none, or all of these may apply. Remove if unnecessary.-->

- [x] Code passes tests.
- [x] New features are documented with docstrings and narrative docs.
- [x] Tests added for fixed bugs or new features.

<!--Thanks!-->
