### PR TITLE
Relax requirements on cosmological parameters and add load options for AHF

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,19 +213,19 @@ workflows:
    normal-tests:
      jobs:
        - tests:
-           name: "Python 3.6 tests"
-           tag: "3.6.12"
+           name: "Python 3.7 tests"
+           tag: "3.7.10"
            ytdev: 1
 
        - tests:
            name: "Python 3.9 tests"
-           tag: "3.9.1"
+           tag: "3.9.2"
            coverage: 1
            ytdev: 1
 
        - docs-test:
            name: "Test docs build"
-           tag: "3.9.1"
+           tag: "3.9.2"
 
    daily:
      triggers:
@@ -238,13 +238,13 @@ workflows:
      jobs:
        - tests:
            name: "Python 3.9 tests with yt-dev"
-           tag: "3.9.1"
+           tag: "3.9.2"
            coverage: 0
            ytdev: 1
 
        - docs-test:
            name: "Test docs build"
-           tag: "3.9.1"
+           tag: "3.9.2"
 
    weekly:
      triggers:
@@ -256,11 +256,6 @@ workflows:
                 - main
      jobs:
        - tests:
-           name: "Python 3.7 tests"
-           tag: "3.7.9"
-           ytdev: 1
-
-       - tests:
            name: "Python 3.8 tests"
-           tag: "3.8.7"
+           tag: "3.8.8"
            ytdev: 1

--- a/doc/source/Loading.rst
+++ b/doc/source/Loading.rst
@@ -22,16 +22,23 @@ of the first ".parameter" file.
    >>> a = ytree.load("ahf_halos/snap_N64L16_000.parameter",
    ...                hubble_constant=0.7)
 
-.. note:: Three important notes about loading AHF data:
+.. note:: Four important notes about loading AHF data:
 
           1. The dimensionless Hubble parameter is not provided in AHF
              outputs.  This should be supplied by hand using the
              ``hubble_constant`` keyword. The default value is 1.0.
 
-          2. There will be no ".AHF_mtree" file for index 0 as the
+          2. If the ".log" file is named in a unconventional way or cannot
+             be found for some reason, its path can be specified with the
+             ``log_filename`` keyword argument. If no log file exists,
+             values for ``omega_matter``, ``omega_lambda``, and ``box_size``
+             (in units of Mpc/h) can be provided with keyword arguments
+             named thusly.
+
+          3. There will be no ".AHF_mtree" file for index 0 as the
              ".AHF_mtree" files store links between files N-1 and N.
 
-          3. ``ytree`` is able to load data where the graph has been
+          4. ``ytree`` is able to load data where the graph has been
              calculated instead of the tree. However, even in this case,
              only the tree is preserved in ``ytree``. See the `Amiga Halo
              Finder Documentation

--- a/setup.py
+++ b/setup.py
@@ -51,9 +51,9 @@ setup(name="ytree",
           "Operating System :: POSIX :: Linux",
           "Operating System :: Unix",
           "Natural Language :: English",
-          "Programming Language :: Python :: 3.6",
           "Programming Language :: Python :: 3.7",
           "Programming Language :: Python :: 3.8",
+          "Programming Language :: Python :: 3.9",
       ],
       install_requires=[
           'configparser',
@@ -66,5 +66,5 @@ setup(name="ytree",
           'dev': dev_requirements,
           'rtd': [pkg for pkg in dev_requirements if 'sphinx' not in pkg],
       },
-      python_requires='>=3.6'
+      python_requires='>=3.7'
 )

--- a/ytree/data_structures/fields.py
+++ b/ytree/data_structures/fields.py
@@ -211,8 +211,9 @@ Check the TypeError exception above for more details.
         self.arbor.add_derived_field(
             "redshift", _redshift, units="", force_add=False)
 
-        self.arbor.add_derived_field(
-            "time", _time, units="Myr", force_add=False)
+        if hasattr(self.arbor, "cosmology"):
+            self.arbor.add_derived_field(
+                "time", _time, units="Myr", force_add=False)
 
     def add_vector_field(self, fieldname):
         """

--- a/ytree/data_structures/fields.py
+++ b/ytree/data_structures/fields.py
@@ -26,6 +26,23 @@ from ytree.utilities.exceptions import \
 from ytree.utilities.logger import \
     ytreeLogger as mylog
 
+def _redshift(field, data):
+    return 1. / data["scale_factor"] - 1.
+
+def _time(field, data):
+    return data.arbor.cosmology.t_from_z(data["redshift"])
+
+def _vector_func(field, data):
+    name = field["name"]
+    field_data = data.arbor.arr([data["%s_%s" % (name, ax)]
+                                 for ax in "xyz"])
+    field_data = np.rollaxis(field_data, 1)
+    return field_data
+
+def _magnitude_func(field, data):
+    name = field["name"][:-len("_magnitude")]
+    return np.sqrt((data[name]**2).sum(axis=1))
+
 class FieldInfoContainer(dict):
     """
     A container for information about fields.
@@ -191,13 +208,9 @@ Check the TypeError exception above for more details.
         """
         Add stock derived fields.
         """
-        def _redshift(field, data):
-            return 1. / data["scale_factor"] - 1.
         self.arbor.add_derived_field(
             "redshift", _redshift, units="", force_add=False)
 
-        def _time(field, data):
-            return data.arbor.cosmology.t_from_z(data["redshift"])
         self.arbor.add_derived_field(
             "time", _time, units="Myr", force_add=False)
 
@@ -207,19 +220,7 @@ Check the TypeError exception above for more details.
         x/y/z components.
         """
 
-        def _vector_func(field, data):
-            name = field["name"]
-            field_data = data.arbor.arr([data["%s_%s" % (name, ax)]
-                                         for ax in axes])
-            field_data = np.rollaxis(field_data, 1)
-            return field_data
-
-        def _magnitude_func(field, data):
-            name = field["name"][:-len("_magnitude")]
-            return np.sqrt((data[name]**2).sum(axis=1))
-
-        axes = "xyz"
-        exists = all([f"{fieldname}_{ax}" in self for ax in axes])
+        exists = all([f"{fieldname}_{ax}" in self for ax in "xyz"])
         if not exists:
             return None
 

--- a/ytree/data_structures/save_arbor.py
+++ b/ytree/data_structures/save_arbor.py
@@ -264,7 +264,7 @@ def save_header_file(arbor, filename, fields, root_field_data,
     for attr in ["hubble_constant",
                  "omega_matter",
                  "omega_lambda"]:
-        if hasattr(arbor, attr):
+        if getattr(arbor, attr, None) is not None:
             ds[attr] = getattr(arbor, attr)
 
     # Data structures for disk fields.
@@ -308,9 +308,10 @@ def save_header_file(arbor, filename, fields, root_field_data,
         tree_start_index = tree_end_index - group_ntrees
 
         extra_attrs = {
-            "box_size": arbor.box_size,
             "arbor_type": "YTreeArbor",
             "unit_registry_json": arbor.unit_registry.to_json()}
+        if arbor.box_size is not None:
+            extra_attrs["box_size"] = arbor.box_size
         extra_attrs["field_info"] = json.dumps(main_fi)
         extra_attrs["total_files"] = group_nnodes.size
         extra_attrs["total_trees"] = group_ntrees.sum()

--- a/ytree/frontends/ahf/arbor.py
+++ b/ytree/frontends/ahf/arbor.py
@@ -116,7 +116,7 @@ class AHFArbor(CatalogArbor):
         self.data_files.reverse()
 
     def _get_file_index(self, f):
-        reg = re.search(f"{self._prefix}_(\d+)\.", self.filename)
+        reg = re.search(rf"{self._prefix}_(\d+)\.", self.filename)
         if not reg:
             raise RuntimeError(
                 f"Could not locate index within file: {self.filename}.")

--- a/ytree/frontends/ahf/arbor.py
+++ b/ytree/frontends/ahf/arbor.py
@@ -15,6 +15,7 @@ AHFArbor class and member functions
 
 import glob
 import os
+import re
 
 from ytree.data_structures.arbor import \
     CatalogArbor
@@ -22,6 +23,8 @@ from ytree.frontends.ahf.fields import \
     AHFFieldInfo
 from ytree.frontends.ahf.io import \
     AHFDataFile
+from ytree.frontends.ahf.misc import \
+    parse_AHF_file
 from unyt.unit_registry import \
     UnitRegistry
 
@@ -34,17 +37,35 @@ class AHFArbor(CatalogArbor):
     _field_info_class = AHFFieldInfo
     _data_file_class = AHFDataFile
 
-    def __init__(self, filename, hubble_constant=1.0):
+    def __init__(self, filename, log_filename=None,
+                 hubble_constant=1.0, box_size=None,
+                 omega_matter=None, omega_lambda=None):
         self.unit_registry = UnitRegistry()
+        self.log_filename = log_filename
         self.hubble_constant = hubble_constant
+        self.omega_matter = omega_matter
+        self.omega_lambda = omega_lambda
+        self._box_size_user = box_size
         super(AHFArbor, self).__init__(filename)
 
     def _parse_parameter_file(self):
         df = AHFDataFile(self.filename, self)
-        for attr in ["omega_matter",
-                     "omega_lambda"]:
-            setattr(self, attr, getattr(df, attr))
-        self.box_size = self.quan(df.box_size, "Mpc/h")
+
+        pars = {"simu.omega0": "omega_matter",
+                "simu.lambda0": "omega_lambda",
+                "simu.boxsize": "box_size"}
+        log_filename = self.log_filename \
+          if self.log_filename is not None else df.filekey + ".log"
+        if os.path.exists(log_filename):
+            vals = parse_AHF_file(log_filename, pars, sep=":")
+            for attr in ["omega_matter",
+                         "omega_lambda"]:
+                setattr(self, attr, vals.get(attr))
+            if "box_size" in vals:
+                self.box_size = self.quan(vals["box_size"], "Mpc/h")
+
+        if self._box_size_user is not None:
+            self.box_size = self.quan(self._box_size_user, "Mpc/h")
 
         # fields from from the .AHF_halos files
         f = open("%s.AHF_halos" % df.data_filekey)
@@ -95,8 +116,11 @@ class AHFArbor(CatalogArbor):
         self.data_files.reverse()
 
     def _get_file_index(self, f):
-        return int(f[f.find(self._prefix) + len(self._prefix)+1:
-                     f.rfind(self._suffix)]),
+        reg = re.search(f"{self._prefix}_(\d+)\.", self.filename)
+        if not reg:
+            raise RuntimeError(
+                f"Could not locate index within file: {self.filename}.")
+        return int(reg.groups()[0])
 
     @classmethod
     def _is_valid(self, *args, **kwargs):
@@ -106,8 +130,5 @@ class AHFArbor(CatalogArbor):
         """
         fn = args[0]
         if not fn.endswith(self._suffix):
-            return False
-        key = fn[:fn.rfind(self._suffix)]
-        if not os.path.exists(key + ".log"):
             return False
         return True

--- a/ytree/frontends/ytree/arbor.py
+++ b/ytree/frontends/ytree/arbor.py
@@ -83,13 +83,14 @@ class YTreeArbor(Arbor):
         for attr in ["hubble_constant",
                      "omega_matter",
                      "omega_lambda"]:
-            setattr(self, attr, fh.attrs[attr])
+            setattr(self, attr, fh.attrs.get(attr, None))
         if "unit_registry_json" in fh.attrs:
             self.unit_registry = \
               UnitRegistry.from_json(
                   parse_h5_attr(fh, "unit_registry_json"))
-        self.box_size = _hdf5_yt_attr(
-            fh, "box_size", unit_registry=self.unit_registry)
+        if "box_size" in fh.attrs:
+            self.box_size = _hdf5_yt_attr(
+                fh, "box_size", unit_registry=self.unit_registry)
         self.field_info.update(
             json.loads(parse_h5_attr(fh, "field_info")))
         self._size = fh.attrs["total_trees"]


### PR DESCRIPTION
<!--Thanks for issuing a PR! To help us review, please provide a
description below. Please see the development guide at
http://ytree.readthedocs.io/en/latest/Developing.html for tips.-->

<!--If possible, please issue your PR from a new branch that is
not the master branch.-->

## PR Summary

This PR relaxes the requirements that cosmology parameters, like hubble_constant, omega_matter, omega_lambda, and box_size be present within the data. It also adds more load keyword for the AHF frontend allowing the user to specify the path to the log file and to give values for all the above parameters if no log file exists.

<!--Describe the changes. Mention any relevant open issues.
If you need help with anything, let us know!-->

## PR Checklist

<!--Some, none, or all of these may apply. Remove if unnecessary.-->

- [ ] Code passes tests.
- [x] New features are documented with docstrings and narrative docs.
- [ ] Tests added for fixed bugs or new features.

<!--Thanks!-->
