### PR TITLE
[bugfix] Use regex for more robust filename check.

### DIFF
--- a/ytree/data_structures/fields.py
+++ b/ytree/data_structures/fields.py
@@ -260,7 +260,7 @@ Check the TypeError exception above for more details.
                 # Check that the field array is the size we want.
                 # It might not be if it was previously gotten just
                 # for the root and now we want it for the whole tree.
-                if fsize is None or fcache[field].size == fsize:
+                if fsize is None or fcache[field].shape[0] == fsize:
                     continue
                 del fcache[field]
 

--- a/ytree/frontends/treefarm/arbor.py
+++ b/ytree/frontends/treefarm/arbor.py
@@ -68,7 +68,7 @@ class TreeFarmArbor(CatalogArbor):
             raise RuntimeError(
                 f"Cannot determine numbering system for {self.filename}.")
         prefix = reg.groups()[0]
-        files = glob.glob(f"{prefix}*{suffix}")
+        files = glob.glob(f"{prefix}*{self._suffix}")
         fids = defaultdict(list)
         for my_file in files:
             fid = int(my_file[len(prefix):-len(suffix)])

--- a/ytree/frontends/treefarm/arbor.py
+++ b/ytree/frontends/treefarm/arbor.py
@@ -17,6 +17,7 @@ from collections import \
     defaultdict
 import glob
 import h5py
+import re
 
 from unyt.unit_registry import \
     UnitRegistry
@@ -61,15 +62,18 @@ class TreeFarmArbor(CatalogArbor):
         fh.close()
 
     def _get_data_files(self):
-        prefix = self.filename.rsplit("_", 1)[0] + "_"
-        files = glob.glob("%s*%s" % (prefix, self._suffix))
         suffix = ".0" + self._suffix
+        reg = re.search(f"^(.+\D)\d+{suffix}$", self.filename)
+        if reg is None:
+            raise RuntimeError(
+                f"Cannot determine numbering system for {self.filename}.")
+        prefix = reg.groups()[0]
+        files = glob.glob(f"{prefix}*{suffix}")
         fids = defaultdict(list)
         for my_file in files:
             fid = int(my_file[len(prefix):-len(suffix)])
             fids[fid].append(my_file)
-        my_files = [fids[myfid]
-                    for myfid in sorted(fids.keys(), reverse=True)]
+        my_files = [fids[myfid] for myfid in sorted(fids.keys(), reverse=True)]
         self.data_files = [[self._data_file_class(f, self)
                             for f in fl] for fl in my_files]
 

--- a/ytree/frontends/treefarm/arbor.py
+++ b/ytree/frontends/treefarm/arbor.py
@@ -63,7 +63,7 @@ class TreeFarmArbor(CatalogArbor):
 
     def _get_data_files(self):
         suffix = ".0" + self._suffix
-        reg = re.search(f"^(.+\D)\d+{suffix}$", self.filename)
+        reg = re.search(rf"^(.+\D)\d+{suffix}$", self.filename)
         if reg is None:
             raise RuntimeError(
                 f"Cannot determine numbering system for {self.filename}.")


### PR DESCRIPTION
<!--Thanks for issuing a PR! To help us review, please provide a
description below. Please see the development guide at
http://ytree.readthedocs.io/en/latest/Developing.html for tips.-->

<!--If possible, please issue your PR from a new branch that is
not the master branch.-->

## PR Summary

This makes the filename checking for treefarm datasets a bit more robust and allows it to work with merger trees made from yt hop/fof.

<!--Describe the changes. Mention any relevant open issues.
If you need help with anything, let us know!-->

## PR Checklist

<!--Some, none, or all of these may apply. Remove if unnecessary.-->

- [ ] Code passes tests.
- [ ] New features are documented with docstrings and narrative docs.
- [ ] Tests added for fixed bugs or new features.

<!--Thanks!-->
