### PR TITLE
Trim select_halos function

### DIFF
--- a/doc/source/Arbor.rst
+++ b/doc/source/Arbor.rst
@@ -446,16 +446,14 @@ set of criteria.
 
 .. code-block:: python
 
-   >>> halos = a.select_halos('tree["tree", "redshift"] > 1',
-   ...                        fields=["redshift"])
+   >>> halos = a.select_halos('tree["tree", "redshift"] > 1')
    >>> print (halos)
    [TreeNode[8987], TreeNode[6713], TreeNode[6091], TreeNode[448], ...,
     TreeNode[9683], TreeNode[8316], TreeNode[10788]]
 
 The selection criteria string should be designed to ``eval`` correctly
 with a :class:`~ytree.data_structures.tree_node.TreeNode` object, named
-"tree". The ``fields`` keyword can be used to specify a list of fields to preload
-for speeding up selection.
+"tree".
 
 .. _select-halos-yt:
 

--- a/ytree/data_structures/arbor.py
+++ b/ytree/data_structures/arbor.py
@@ -745,11 +745,8 @@ class Arbor(metaclass=RegisteredArbor):
             string of 'tree["tree", "redshift"] > 1' cannot be used when setting
             select_from to "prog".
             Default: "tree".
-        fields : optional, list of strings
-            Use to provide a list of fields required by the criteria evaluation.
-            If given, fields will be preloaded in an optimized way and the search
-            will go faster.
-            Default: None.
+        fields : deprecated, do not use
+            This keyword is no longer required and using it does nothing.
 
         Returns
         -------
@@ -762,11 +759,10 @@ class Arbor(metaclass=RegisteredArbor):
 
         >>> import ytree
         >>> a = ytree.load("tree_0_0_0.dat")
-        >>> halos = a.select_halos('tree["tree", "redshift"] > 1',
-        ...                        fields=["redshift"])
+        >>> halos = a.select_halos('tree["tree", "redshift"] > 1')
         >>>
         >>> halos = a.select_halos('tree["prog", "mass"].to("Msun") >= 1e10',
-        ...                        select_from="prog", fields=["mass"])
+        ...                        select_from="prog")
 
         """
 
@@ -775,19 +771,14 @@ class Arbor(metaclass=RegisteredArbor):
                 "Keyword \"select_from\" must be \"tree\", \"forest\", or \"prog\".")
 
         if trees is None:
-            trees = self[:]
+            trees = self
 
-        if fields is None:
-            fields = []
-
-        self._node_io_loop(self._setup_tree, root_nodes=trees,
-                           pbar="Setting up trees")
-        if fields:
-            self._node_io_loop(
-                self._node_io.get_fields,
-                pbar="Getting fields",
-                root_nodes=trees, fields=fields, root_only=False)
-
+        if fields is not None:
+            import warnings
+            from numpy import VisibleDeprecationWarning
+            warnings.warn(
+                "The fields keyword is deprecated and no longer does anything.",
+                VisibleDeprecationWarning, stacklevel=2)
 
         halos = []
         pbar = get_pbar("Selecting halos", trees.size)


### PR DESCRIPTION
This deprecates the `fields` keyword, which was not speeding things up and removes some other optimizations that were actually just taking more time.

<!--Thanks for issuing a PR! To help us review, please provide a
description below. Please see the development guide at
http://ytree.readthedocs.io/en/latest/Developing.html for tips.-->

<!--If possible, please issue your PR from a new branch that is
not the master branch.-->

## PR Summary

<!--Describe the changes. Mention any relevant open issues.
If you need help with anything, let us know!-->

## PR Checklist

<!--Some, none, or all of these may apply. Remove if unnecessary.-->

- [ ] Code passes tests.
- [ ] New features are documented with docstrings and narrative docs.
- [ ] Tests added for fixed bugs or new features.

<!--Thanks!-->
