### PR TITLE
improved sorting for node_io_loop in ctrees_group and ctrees_hdf5

### DIFF
--- a/ytree/frontends/consistent_trees/arbor.py
+++ b/ytree/frontends/consistent_trees/arbor.py
@@ -147,15 +147,18 @@ class ConsistentTreesGroupArbor(ConsistentTreesArbor):
         if nodes is None:
             nodes = np.arange(self.size)
             fi = self._node_info['_fi']
+            si = self._node_info['_si']
         elif nodes.dtype == object:
-            fi = np.array(
-                [node._fi if node.is_root else node.root._fi
-                 for node in nodes])
+            fi = np.array([node._fi if node.is_root else node.root._fi
+                           for node in nodes])
+            si = np.array([node._si if node.is_root else node.root._si
+                           for node in nodes])
         else: # assume an array of indices
             fi = self._node_info['_fi'][nodes]
+            si = self._node_info['_si'][nodes]
 
         # the order they will be processed
-        io_order = np.argsort(fi)
+        io_order = np.lexsort((fi, si))
         fi = fi[io_order]
         # array to return them to original order
         return_order = np.empty_like(io_order)

--- a/ytree/frontends/consistent_trees/arbor.py
+++ b/ytree/frontends/consistent_trees/arbor.py
@@ -158,7 +158,7 @@ class ConsistentTreesGroupArbor(ConsistentTreesArbor):
             si = self._node_info['_si'][nodes]
 
         # the order they will be processed
-        io_order = np.lexsort((fi, si))
+        io_order = np.lexsort((si, fi))
         fi = fi[io_order]
         # array to return them to original order
         return_order = np.empty_like(io_order)

--- a/ytree/frontends/consistent_trees_hdf5/arbor.py
+++ b/ytree/frontends/consistent_trees_hdf5/arbor.py
@@ -183,7 +183,7 @@ class ConsistentTreesHDF5Arbor(Arbor):
 
         c = 0
         file_offsets = self._file_count.cumsum() - self._file_count
-        pbar = get_pbar('Planting %ss' % self.access, self._size)
+        pbar = get_pbar(f'Planting {self.access}s', self._size)
         for idf, data_file in enumerate(self.data_files):
             data_file.open()
             hostids = data_file.fh[groupname][hostname][()]
@@ -197,6 +197,7 @@ class ConsistentTreesHDF5Arbor(Arbor):
             self._node_info['_fi'][istart:iend] = idf
             self._node_info['_si'][istart:iend] = offsets
             self._node_info['_ei'][istart:iend] = offsets + tree_sizes
+            self._node_info['_tree_size'][istart:iend] = tree_sizes
             c += offsets.size
             pbar.update(c)
         pbar.finish()

--- a/ytree/utilities/testing.py
+++ b/ytree/utilities/testing.py
@@ -246,7 +246,8 @@ def compare_arbors(a1, a2, groups=None, fields=None, skip1=1, skip2=1):
 
     for i, field in enumerate(fields):
         mylog.info(f"Comparing arbor field: {field} ({i+1}/{len(fields)}).")
-        assert (a1[field][::skip1] == a2[field][::skip2]).all()
+        assert_array_equal(a1[field][::skip1], a2[field][::skip2],
+                           err_msg=f"Arbor field mismatch: {a1, a2, field}.")
 
     trees1 = a1[::skip1]
     trees2 = a2[::skip2]


### PR DESCRIPTION
<!--Thanks for issuing a PR! To help us review, please provide a
description below. Please see the development guide at
http://ytree.readthedocs.io/en/latest/Developing.html for tips.-->

<!--If possible, please issue your PR from a new branch that is
not the master branch.-->

## PR Summary

The `_node_io_loop` was only sorting trees by file index but the order within a single file was ending up scrambled. Trees were being iterated on out of order, creating cache misses just about every time. This will put them back in to order and seems to speed up the io loops quite a bit.

I also took the opportunity to capture the size of each tree when we have it during the plant trees phase so we can use it later in the saving. This speeds up a portion of that astronomically.

<!--Describe the changes. Mention any relevant open issues.
If you need help with anything, let us know!-->

## PR Checklist

<!--Some, none, or all of these may apply. Remove if unnecessary.-->

- [ ] Code passes tests.
- [ ] New features are documented with docstrings and narrative docs.
- [ ] Tests added for fixed bugs or new features.

<!--Thanks!-->
