### PR TITLE
TreeFrog: detect correct filename if data file given instead

### DIFF
--- a/tests/frontends/test_treefrog.py
+++ b/tests/frontends/test_treefrog.py
@@ -1,3 +1,4 @@
+from ytree.data_structures.load import load as ytree_load
 from ytree.frontends.treefrog import \
     TreeFrogArbor
 from ytree.utilities.testing import \
@@ -18,3 +19,8 @@ class TreeFrogArborTest(TempDirTest, ArborTest):
             arbor.add_alias_field(
                 "mass", "Mass_200crit", units="Msun")
         return arbor
+
+    def test_load_from_datafile(self):
+        for df in self.arbor.data_files:
+            new_arbor = ytree_load(df.filename)
+            assert isinstance(new_arbor, self.arbor_type)

--- a/ytree/frontends/treefrog/arbor.py
+++ b/ytree/frontends/treefrog/arbor.py
@@ -16,6 +16,7 @@ TreeFrogArbor class and member functions
 import h5py
 import numpy as np
 import os
+import re
 
 from ytree.data_structures.arbor import \
     SegmentedArbor
@@ -38,6 +39,23 @@ class TreeFrogArbor(SegmentedArbor):
     _field_info_class = TreeFrogFieldInfo
     _root_field_io_class = TreeFrogRootFieldIO
     _tree_field_io_class = TreeFrogTreeFieldIO
+
+    def __init__(self, filename):
+        filename = self._determine_filename(filename)
+        super().__init__(filename)
+
+    def _determine_filename(self, filename):
+        """
+        Find the proper parameter filename if given a data file instead.
+        """
+
+        suffix = f".foreststats{self._suffix}"
+        if filename.endswith(suffix):
+            return filename
+
+        match = re.search(rf"{self._suffix}\.\d+$", filename)
+        forest_fn = filename[:match.start()] + suffix
+        return forest_fn
 
     def _get_data_files(self):
         self.data_files = [TreeFrogDataFile(f"{self._prefix}{self._suffix}.{i}")
@@ -114,7 +132,7 @@ class TreeFrogArbor(SegmentedArbor):
         """
         Should be an hdf5 file with a few key attributes.
         """
-        fn = args[0]
+        fn = self._determine_filename(self, args[0])
         suffix = f".foreststats{self._suffix}"
         if not fn.endswith(suffix):
             return False


### PR DESCRIPTION
<!--Thanks for issuing a PR! To help us review, please provide a
description below. Please see the development guide at
http://ytree.readthedocs.io/en/latest/Developing.html for tips.-->

<!--If possible, please issue your PR from a new branch that is
not the master branch.-->

## PR Summary

This resolves Issue #98 by introducing a function to get the forest stats filename from a given data filename.

<!--Describe the changes. Mention any relevant open issues.
If you need help with anything, let us know!-->

## PR Checklist

<!--Some, none, or all of these may apply. Remove if unnecessary.-->

- [ ] Code passes tests.
- [ ] New features are documented with docstrings and narrative docs.
- [x] Tests added for fixed bugs or new features.

<!--Thanks!-->
