### PR TITLE
Make field_data an public facing attribute.

### DIFF
--- a/ytree/data_structures/arbor.py
+++ b/ytree/data_structures/arbor.py
@@ -193,7 +193,7 @@ class Arbor(metaclass=RegisteredArbor):
         """
         Setup field containers and definitions.
         """
-        self._field_data = FieldContainer(self)
+        self.field_data = FieldContainer(self)
         self.derived_field_list = []
         self.analysis_field_list = []
         self.field_info.setup_known_fields()
@@ -280,8 +280,8 @@ class Arbor(metaclass=RegisteredArbor):
         tree_node._uids      = field_data[halo_id_f]
         tree_node._desc_uids = field_data[desc_id_f]
         tree_node._tree_size = tree_node._uids.size
-        tree_node._field_data["uid"] = tree_node._uids
-        tree_node._field_data["desc_uid"] = tree_node._desc_uids
+        tree_node.field_data["uid"] = tree_node._uids
+        tree_node.field_data["desc_uid"] = tree_node._desc_uids
 
     def is_grown(self, tree_node):
         """
@@ -530,7 +530,7 @@ class Arbor(metaclass=RegisteredArbor):
             if key in ("tree", "prog"):
                 raise SyntaxError("Argument must be a field or integer.")
             self._root_io.get_fields(self, fields=[key])
-            return self._field_data[key]
+            return self.field_data[key]
         return self._generate_root_nodes(key)
 
     def _generate_root_nodes(self, key):
@@ -1256,8 +1256,8 @@ class CatalogArbor(Arbor):
         # This should bypass any attempt to get this field in
         # the conventional way.
         if self.field_info["uid"].get("source") == "arbor":
-            tree_node._field_data["uid"] = tree_node._uids
-            tree_node._field_data["desc_uid"] = tree_node._desc_uids
+            tree_node.field_data["uid"] = tree_node._uids
+            tree_node.field_data["desc_uid"] = tree_node._desc_uids
 
     def _grow_tree(self, tree_node):
         """

--- a/ytree/data_structures/io.py
+++ b/ytree/data_structures/io.py
@@ -79,7 +79,7 @@ class FieldIO:
         """
         Only keep items on the fields list.
         """
-        fcache = storage_object._field_data
+        fcache = storage_object.field_data
         remove = set(fcache).difference(fields)
         for field in remove:
             del fcache[field]
@@ -99,7 +99,7 @@ class FieldIO:
 
         storage_object = \
           self._determine_field_storage(data_object)
-        fcache = storage_object._field_data
+        fcache = storage_object.field_data
 
         fi = self.arbor.field_info
 
@@ -158,7 +158,7 @@ class FieldIO:
                 fcache[field] = data
 
         self._store_fields(storage_object, set(old_fields).union(fields))
-        return storage_object._field_data
+        return storage_object.field_data
 
 class TreeFieldIO(FieldIO):
     """
@@ -166,7 +166,7 @@ class TreeFieldIO(FieldIO):
     """
 
     def _initialize_analysis_field(self, storage_object, name):
-        if name in storage_object._field_data:
+        if name in storage_object.field_data:
             return
         fi = self.arbor.field_info[name]
         units = fi.get('units', '')
@@ -175,7 +175,7 @@ class TreeFieldIO(FieldIO):
         data = np.full(storage_object.tree_size, value, dtype=dtype)
         if units:
             data = self.arbor.arr(data, units)
-        storage_object._field_data[name] = data
+        storage_object.field_data[name] = data
 
     def _determine_field_storage(self, data_object):
         return data_object.find_root()
@@ -238,7 +238,7 @@ class DefaultRootFieldIO(FieldIO):
         dtype   = fi['dtype']
         units   = fi['units']
 
-        storage_object._field_data[name] = \
+        storage_object.field_data[name] = \
           self.arbor.arr(np.full(self.arbor.size, default, dtype=dtype), units)
 
     def _read_fields(self, storage_object, fields, dtypes=None,

--- a/ytree/data_structures/save_arbor.py
+++ b/ytree/data_structures/save_arbor.py
@@ -238,7 +238,7 @@ def save_data_file(arbor, filename, fields, tree_group,
 
         my_ftypes[fieldname] = "data"
         my_fdata[fieldname]  = uconcatenate(
-            [node._field_data[field] if node.is_root else node["tree", field]
+            [node.field_data[field] if node.is_root else node["tree", field]
              for node in tree_group])
         root_field_data[field].append(my_fdata[fieldname][my_tree_start])
 

--- a/ytree/data_structures/tree_node.py
+++ b/ytree/data_structures/tree_node.py
@@ -43,7 +43,7 @@ class TreeNode:
         self.arbor = weakref.proxy(arbor)
         if root:
             self.root = -1
-            self._field_data = FieldContainer(arbor)
+            self.field_data = FieldContainer(arbor)
         else:
             self.root = None
 
@@ -108,7 +108,7 @@ class TreeNode:
 
         if not self.is_root:
             return
-        self._field_data.clear()
+        self.field_data.clear()
 
     _descendent = None # used by CatalogArbor
     @property
@@ -234,7 +234,7 @@ class TreeNode:
             tree_id = self.tree_id
         self.arbor._node_io.get_fields(self, fields=[key],
                                        root_only=False)
-        data = root._field_data[key]
+        data = root.field_data[key]
         data[tree_id] = value
 
     def __getitem__(self, key):
@@ -299,7 +299,7 @@ class TreeNode:
             indices = getattr(self, f"_{ftype}_field_indices")
 
             data_object = self.find_root()
-            return data_object._field_data[field][indices]
+            return data_object.field_data[field][indices]
 
         else:
             if not isinstance(key, str):
@@ -314,7 +314,7 @@ class TreeNode:
             self.arbor._node_io.get_fields(self, fields=[key],
                                            root_only=self.is_root)
             data_object = self.find_root()
-            return data_object._field_data[key][self.tree_id]
+            return data_object.field_data[key][self.tree_id]
 
     def __repr__(self):
         """

--- a/ytree/frontends/treefrog/io.py
+++ b/ytree/frontends/treefrog/io.py
@@ -153,7 +153,7 @@ class TreeFrogTreeFieldIO(TreeFieldIO):
         if close:
             data_file.close()
 
-        field_data = root_node._field_data
+        field_data = root_node.field_data
         for field in fields:
             field_data[field] = rdata[field]
             dtype = my_dtypes.get(field, fi[field].get("dtype", None))

--- a/ytree/utilities/testing.py
+++ b/ytree/utilities/testing.py
@@ -153,7 +153,7 @@ class ArborTest:
 
         for attr in self.arbor._reset_attrs:
             assert getattr(t, attr) is None
-        assert_equal(len(t._field_data), 0)
+        assert_equal(len(t.field_data), 0)
         assert not self.arbor.is_setup(t)
         assert not self.arbor.is_grown(t)
 


### PR DESCRIPTION
<!--Thanks for issuing a PR! To help us review, please provide a
description below. Please see the development guide at
http://ytree.readthedocs.io/en/latest/Developing.html for tips.-->

<!--If possible, please issue your PR from a new branch that is
not the master branch.-->

## PR Summary

This renames the `_field_data` attribute associated with root `TreeNode` and `Arbor` to `field_data`, effectively making it a public-facing attribute. I have done this as accessing this attribute is the most straightforward way to combine results after running in parallel. Making it public facing will make this method seem a bit more reliable.

<!--Describe the changes. Mention any relevant open issues.
If you need help with anything, let us know!-->

## PR Checklist

<!--Some, none, or all of these may apply. Remove if unnecessary.-->

- [ ] Code passes tests.
- [ ] New features are documented with docstrings and narrative docs.
- [ ] Tests added for fixed bugs or new features.

<!--Thanks!-->
