### PR TITLE
correct error in analysis field docs

### DIFF
--- a/doc/source/Fields.rst
+++ b/doc/source/Fields.rst
@@ -183,14 +183,16 @@ or :func:`~ytree.data_structures.tree_node.TreeNode.save_tree`.
 
 .. code-block:: python
 
-   >>> my_trees = a[:] # all trees
+   >>> my_trees = list(a[:]) # all trees
    >>> for my_tree in my_trees:
    ...     # do analysis...
    >>> a.save_arbor(trees=my_trees)
 
-.. note:: Trees with altered analysis fields must be provided explicitly to
-   :func:`~ytree.data_structures.arbor.Arbor.save_arbor` in order for fields
-   to be saved properly.
+Note that we do ``my_trees = list(a[:])`` and not just ``my_trees =
+a[:]``. This is because ``a[:]`` is a generator that will return a new
+set of trees each time. The newly generated trees will not retain
+changes made to any analysis fields. Thus, we must use ``list(a[:])``
+to explicitly store a list of trees.
 
 Re-saving Analysis Fields
 ^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
<!--Thanks for issuing a PR! To help us review, please provide a
description below. Please see the development guide at
http://ytree.readthedocs.io/en/latest/Developing.html for tips.-->

<!--If possible, please issue your PR from a new branch that is
not the master branch.-->

## PR Summary

This corrects an error showing a loop over halos that does not use a persistent data structure, which would not allow analysis fields to be saved correctly. I've fixed this and added an expanded discussion.
<!--Describe the changes. Mention any relevant open issues.
If you need help with anything, let us know!-->

## PR Checklist

<!--Some, none, or all of these may apply. Remove if unnecessary.-->

<!--Thanks!-->
