### PR TITLE
Fix analysis pipeline operation filtering and add always_do option.

### DIFF
--- a/doc/source/Analysis.rst
+++ b/doc/source/Analysis.rst
@@ -181,6 +181,8 @@ function will be appended to that. Following the examples here, the
 resulting directory would be "my_analysis/images", and the code above
 will correctly save to that location.
 
+.. _operation-as-filter:
+
 Using a Function as a Filter
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -196,6 +198,33 @@ performed. For example, we might create a mass filter like this:
 
    # later, in the pipeline
    ap.add_operation(minimum_mass, a.quan(1e11, "Msun"))
+
+The pipeline will interpret any return value from an operation that is
+not ``None`` in a boolean context to use as a filter.
+
+.. _operation-always-do:
+
+Adding Operations that Always Run
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+As discussed above in :ref:`operation-as-filter`, returning ``False``
+from an operation will prevent all further operations in the pipeline
+from being performed on that node. However, there may be operations
+that you want to always run, regardless of previous filters. For
+example, there may be clean up operations, like freeing up memory,
+that should run for every node, no matter what. To accomplish this,
+the ``always_do`` keyword can be set to ``True`` in the call to
+:func:`~ytree.analysis.analysis_pipeline.AnalysisPipeline.add_operation`.
+
+.. code-block:: python
+
+   def delete_attributes(node, attributes):
+       for attr in attributes:
+           if hasattr(node, attr):
+               delattr(node, attr)
+
+   # later, in the pipeline
+   ap.add_operation(delete_attributes, ["ds", "sphere"], always_do=True)
 
 Modifying a Node
 ^^^^^^^^^^^^^^^^
@@ -240,10 +269,14 @@ add it to the end of the pipeline.
 
    def delete_attributes(node, attributes):
        for attr in attributes:
-           delattr(node, attr)
+           if hasattr(node, attr):
+               delattr(node, attr)
 
    # later, in the pipeline
-   ap.add_operation(delete_attributes, ["ds", "sphere"])
+   ap.add_operation(delete_attributes, ["ds", "sphere"], always_do=True)
+
+See :ref:`operation-always-do` for a discussion of the ``always_do``
+option.
 
 Running the Pipeline
 ^^^^^^^^^^^^^^^^^^^^

--- a/ytree/analysis/analysis_operators.py
+++ b/ytree/analysis/analysis_operators.py
@@ -20,8 +20,9 @@ class AnalysisOperation:
         :class:`~ytree.data_structures.tree_node.TreeNode` object. The
         function may also accept additional positional and keyword arguments.
     """
-    def __init__(self, function, *args, **kwargs):
+    def __init__(self, function, *args, always_do=False, **kwargs):
         self.function = function
+        self.always_do = always_do
         self.args = args
         self.kwargs = kwargs
 

--- a/ytree/analysis/analysis_pipeline.py
+++ b/ytree/analysis/analysis_pipeline.py
@@ -5,7 +5,6 @@ AnalysisPipeline class and member functions
 
 """
 
-import numpy as np
 import os
 
 from yt.utilities.parallel_tools.parallel_analysis_interface import parallel_root_only

--- a/ytree/analysis/analysis_pipeline.py
+++ b/ytree/analysis/analysis_pipeline.py
@@ -163,10 +163,8 @@ class AnalysisPipeline:
         target_filter = True
         for action in self.actions:
             rval = action(target)
-            if isinstance(rval, bool) or \
-              (isinstance(rval, np.ndarray) and rval.size == 1 and
-               rval.dtype == bool):
-                target_filter = rval
+            if rval is not None:
+                target_filter = bool(rval)
             if not target_filter:
                 break
 

--- a/ytree/analysis/analysis_pipeline.py
+++ b/ytree/analysis/analysis_pipeline.py
@@ -44,12 +44,16 @@ class AnalysisPipeline:
     >>> def my_recipe(pipeline):
     ...     pipeline.add_operation(my_analysis)
     >>>
+    >>> def do_cleanup(node):
+    ...     print (f"End of analysis for {node}.")
+    >>>
     >>> a = ytree.load("arbor/arbor.h5")
     >>>
     >>> ap = AnalysisPipeline()
     >>> # don't analyze halos below 3e11 Msun
     >>> ap.add_operation(minimum_mass, 3e11)
     >>> ap.add_recipe(my_recipe)
+    >>> ap.add_recipe(do_cleanup, always_do=True)
     >>>
     >>> trees = list(a[:])
     >>> for tree in trees:
@@ -66,7 +70,7 @@ class AnalysisPipeline:
         self.output_dir = ensure_dir(output_dir)
         self._preprocessed = False
 
-    def add_operation(self, function, *args, **kwargs):
+    def add_operation(self, function, *args, always_do=False, **kwargs):
         """
         Add an operation to the AnalysisPipeline.
 
@@ -85,6 +89,11 @@ class AnalysisPipeline:
             The function to be called for each node/halo.
         *args : positional arguments
             Any additional positional arguments to be provided to the funciton.
+        always_do: optional, bool
+            If True, always perform this operation even if a prior filter has
+            returned False. This can be used to add house cleaning operations
+            that should always be run.
+            Default: False
         **kwargs : keyword arguments
             Any keyword arguments to be provided to the function.
         """
@@ -92,7 +101,7 @@ class AnalysisPipeline:
         if not callable(function):
             raise ValueError("function argument must be a callable function.")
 
-        operation = AnalysisOperation(function, *args, **kwargs)
+        operation = AnalysisOperation(function, *args, always_do=always_do, **kwargs)
         self.actions.append(operation)
 
     def add_recipe(self, function, *args, **kwargs):
@@ -162,10 +171,9 @@ class AnalysisPipeline:
         self._preprocess()
         target_filter = True
         for action in self.actions:
-            rval = action(target)
-            if rval is not None:
-                target_filter = bool(rval)
-            if not target_filter:
-                break
+            if target_filter or action.always_do:
+                rval = action(target)
+                if rval is not None:
+                    target_filter &= bool(rval)
 
         return target_filter


### PR DESCRIPTION
<!--Thanks for issuing a PR! To help us review, please provide a
description below. Please see the development guide at
http://ytree.readthedocs.io/en/latest/Developing.html for tips.-->

<!--If possible, please issue your PR from a new branch that is
not the master branch.-->

## PR Summary

Instead of trying to specifically detect boolean return values from analysis pipeline operations, we now interpret any non-None return value as a boolean for filtering. This avoids increasingly complex checks to correctly detecting all boolean-like values. This also adds an `always_do` option to `add_operation`, which allows an operation to be run regardless of prior filters. This can be useful for adding cleanup functions at the ends of pipelines.

<!--Describe the changes. Mention any relevant open issues.
If you need help with anything, let us know!-->

## PR Checklist

<!--Some, none, or all of these may apply. Remove if unnecessary.-->

- [ ] Code passes tests.
- [ ] New features are documented with docstrings and narrative docs.
- [ ] Tests added for fixed bugs or new features.

<!--Thanks!-->
