### PR TITLE
Get filename from correct part of line in consistent-trees format.

### DIFF
--- a/ytree/frontends/consistent_trees/arbor.py
+++ b/ytree/frontends/consistent_trees/arbor.py
@@ -144,7 +144,7 @@ class ConsistentTreesGroupArbor(ConsistentTreesArbor):
         if not line:
             raise ArborDataFileEmpty(self.filename)
 
-        fn = os.path.join(self.directory, line.split()[-1])
+        fn = os.path.join(self.directory, line.split()[3])
         super()._parse_parameter_file(filename=fn, ntrees_in_file=False)
 
     def _plant_trees(self):


### PR DESCRIPTION
<!--Thanks for issuing a PR! To help us review, please provide a
description below. Please see the development guide at
http://ytree.readthedocs.io/en/latest/Developing.html for tips.-->

<!--If possible, please issue your PR from a new branch that is
not the master branch.-->

## PR Summary

<!--Describe the changes. Mention any relevant open issues.
If you need help with anything, let us know!-->

## PR Checklist

Sometimes the locations.dat file has extra columns than the sample data. This fixes an inconsistency in getting the filenames from that file.

<!--Some, none, or all of these may apply. Remove if unnecessary.-->

- [ ] Code passes tests.

<!--Thanks!-->
