### PR TITLE
Add TreeContainer convenience class.

### DIFF
--- a/ytree/data_structures/arbor.py
+++ b/ytree/data_structures/arbor.py
@@ -46,6 +46,7 @@ from ytree.data_structures.node_link import \
     NodeLink
 from ytree.data_structures.save_arbor import \
     save_arbor
+from ytree.data_structures.tree_container import TreeContainer
 from ytree.data_structures.tree_node import \
     TreeNode
 from ytree.data_structures.tree_node_selector import \
@@ -55,6 +56,7 @@ from ytree.utilities.logger import \
     fake_pbar
 
 arbor_registry = {}
+_selection_types = ("forest", "tree", "prog")
 
 class RegisteredArbor(type):
     """
@@ -527,7 +529,7 @@ class Arbor(metaclass=RegisteredArbor):
         """
 
         if isinstance(key, str):
-            if key in ("tree", "prog"):
+            if key in _selection_types:
                 raise SyntaxError("Argument must be a field or integer.")
             self._root_io.get_fields(self, fields=[key])
             return self.field_data[key]
@@ -735,6 +737,13 @@ class Arbor(metaclass=RegisteredArbor):
         self._quan = functools.partial(unyt_quantity,
                                        registry=self.unit_registry)
         return self._quan
+
+    _container = None
+    @property
+    def container(self):
+        if self._container is None:
+            self._container = functools.partial(TreeContainer, self)
+        return self._container
 
     def select_halos(self, criteria, trees=None,
                      select_from=None, fields=None):

--- a/ytree/data_structures/tree_container.py
+++ b/ytree/data_structures/tree_container.py
@@ -1,0 +1,37 @@
+import numpy as np
+import types
+
+from ytree.data_structures.fields import FieldContainer
+
+_selection_types = ("forest", "tree", "prog")
+
+class TreeContainer:
+    def __init__(self, arbor, trees):
+        self._trees = trees
+        self.field_data = FieldContainer(arbor)
+
+    @property
+    def trees(self):
+        if isinstance(self._trees, types.GeneratorType):
+            self._trees = list(self._trees)
+        return self._trees
+
+    def __iter__(self):
+        return self.trees
+
+    def __getitem__(self, key):
+        if isinstance(key, str):
+            if key in _selection_types:
+                raise SyntaxError("Argument must be a field or integer.")
+
+            if key not in self.field_data:
+                self.field_data[key] = self.field_data.arbor.arr(
+                    [tree[key] for tree in self.trees])
+            return self.field_data[key]
+
+        if isinstance(key, (int, np.integer, slice)):
+            return self.trees[key]
+
+        else:
+            raise ValueError(
+                f"Unrecognized argument type: {key} ({type(key)}).")


### PR DESCRIPTION
<!--Thanks for issuing a PR! To help us review, please provide a
description below. Please see the development guide at
http://ytree.readthedocs.io/en/latest/Developing.html for tips.-->

<!--If possible, please issue your PR from a new branch that is
not the master branch.-->

## PR Summary

This adds a new `TreeContainer` class for holding a persistent collection of trees. The `trees` attribute consists of a list of all trees it contains. This will keep them around so they can be used to compute and save analysis fields. The `TreeContainer` can also be queried like the main arbor to return the value of a field for the root of each tree it contains. Example syntax:
```
import ytree
a = ytree.load("arbor/arbor.h5")

# every 2nd tree
tc = a.container(a[::2])
print (tc["mass"])
print (tc[0])
```

The `TreeContainer` can also hold non-root trees with the same functionality.
```
import ytree
a = ytree.load("arbor/arbor.h5")

# get two distinct sub-trees from the first tree
t = a[0]
for h in t['forest']:
    if len(list(h.ancestors)) > 1:
        break
my_trees = list(h.ancestors)
tc = a.container(my_trees)
```

## PR Checklist

<!--Some, none, or all of these may apply. Remove if unnecessary.-->

- [ ] Code passes tests.
- [ ] New features are documented with docstrings and narrative docs.
- [ ] Tests added for fixed bugs or new features.

<!--Thanks!-->
