### PR TITLE
Add script to fix filename in junit output.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,6 +97,7 @@ commands:
             source $HOME/venv/bin/activate
             TESTFILES=$(circleci tests glob "tests/*.py" "tests/frontends/*.py" | circleci tests split --split-by=timings)
             pytest --cov=ytree --junitxml=test-results/junit.xml $TESTFILES
+            python fix-junit.py test-results/junit.xml
             if [ << parameters.coverage >> == 1 ]; then
                 # code coverage report
                 codecov

--- a/fix-junit.py
+++ b/fix-junit.py
@@ -1,0 +1,27 @@
+"""
+Alter the xml file produced by pytest so the file attribute
+reflects the script file and not the file of the base class.
+"""
+
+import os
+import sys
+import xml.etree.ElementTree as ET
+
+if __name__ == "__main__":
+    ifn = sys.argv[1]
+    print (f"Reading {ifn}.")
+    tree = ET.parse(ifn)
+    root = tree.getroot()
+
+    for child in root[0]:
+        fn = child.attrib["file"]
+        if fn.startswith("tests"):
+            continue
+
+        cln = child.attrib["classname"]
+        fnew = os.path.join(*cln.split(".")[:-1]) + ".py"
+        print (f"Changing {fn} to {fnew}.")
+        child.attrib["file"] = fnew
+
+    print (f"Writing {ifn}.")
+    tree.write(ifn)


### PR DESCRIPTION
<!--Thanks for issuing a PR! To help us review, please provide a
description below. Please see the development guide at
http://ytree.readthedocs.io/en/latest/Developing.html for tips.-->

<!--If possible, please issue your PR from a new branch that is
not the master branch.-->

## PR Summary

This adds a simple script to modify the contents of the xml file produced by pytest on circleci so that the file entry reflects the test script and not the file of the base class. I hope this will allow the circleci parallelism to work a bit better.
<!--Describe the changes. Mention any relevant open issues.
If you need help with anything, let us know!-->

## PR Checklist

<!--Some, none, or all of these may apply. Remove if unnecessary.-->

- [ ] Code passes tests.
- [ ] New features are documented with docstrings and narrative docs.
- [ ] Tests added for fixed bugs or new features.

<!--Thanks!-->
