### PR TITLE
Update AHF format

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,13 +169,13 @@ jobs:
 
       - restore_cache:
           name: "Restore test data cache."
-          key: test-data-abbey
+          key: test-data-abernathy
 
       - download-test-data
 
       - save_cache:
           name: "Save test data cache."
-          key: test-data-abbey
+          key: test-data-abernathy
           paths:
             - ~/ytree_test
 

--- a/doc/source/Loading.rst
+++ b/doc/source/Loading.rst
@@ -11,11 +11,15 @@ use the freely available :ref:`sample-data`.
 Amiga Halo Finder
 -----------------
 
-The `Amiga Halo Finder <http://popia.ft.uam.es/AHF/Download.html>`__ format
-stores data in a series of files, with one each per snapshot.  Parameters
-are stored in ".parameters" and ".log" files, halo information in
-".AHF_halos" files, and descendent/ancestor links are stored in ".AHF_mtree"
-files.  Make sure to keep all of these together.  To load, provide the name
+There are a couple data formats associated with the `Amiga Halo Finder
+<http://popia.ft.uam.es/AHF/Download.html>`__. Both formats save a
+series of files associated with each snapshot. Parameters are stored
+in ".parameters" and ".log" files and halo properties in ".AHF_halos"
+files. In the older format, descendent/ancestor links are stored in
+several ".AHF_mtree" files, one per snapshot. In the newer format, all
+halo linking information is stored in a single file beginning with
+"MergerTree\_" and ending with "-CRMratio2". Make sure to keep all
+these files together in the same directory. To load, provide the name
 of the first ".parameter" file.
 
 .. code-block:: python
@@ -23,6 +27,14 @@ of the first ".parameter" file.
    >>> import ytree
    >>> a = ytree.load("ahf_halos/snap_N64L16_000.parameter",
    ...                hubble_constant=0.7)
+
+Alternatively, the "MergerTree\_" file can also be provided for the
+newer format.
+
+.. code-block:: python
+
+   >>> import ytree
+   >>> a = ytree.load("AHF_100_tiny/MergerTree_GIZMO-NewMDCLUSTER_0047.txt-CRMratio2")
 
 .. note:: Four important notes about loading AHF data:
 

--- a/doc/source/Loading.rst
+++ b/doc/source/Loading.rst
@@ -12,12 +12,12 @@ Amiga Halo Finder
 -----------------
 
 There are a couple data formats associated with the `Amiga Halo Finder
-<http://popia.ft.uam.es/AHF/Download.html>`__. Both formats save a
-series of files associated with each snapshot. Parameters are stored
-in ".parameters" and ".log" files and halo properties in ".AHF_halos"
-files. In the older format, descendent/ancestor links are stored in
-several ".AHF_mtree" files, one per snapshot. In the newer format, all
-halo linking information is stored in a single file beginning with
+<http://popia.ft.uam.es/AHF/>`__. Both formats save a series of files
+associated with each snapshot. Parameters are stored in ".parameters"
+and ".log" files and halo properties in ".AHF_halos" files. In the
+older format, descendent/ancestor links are stored in several
+".AHF_mtree" files, one per snapshot. In the newer format, all halo
+linking information is stored in a single file beginning with
 "MergerTree\_" and ending with "-CRMratio2". Make sure to keep all
 these files together in the same directory. To load, provide the name
 of the first ".parameter" file.

--- a/tests/frontends/test_ahf.py
+++ b/tests/frontends/test_ahf.py
@@ -1,5 +1,6 @@
 from ytree.frontends.ahf import \
-    AHFArbor
+    AHFArbor, \
+    AHFNewArbor
 from ytree.utilities.testing import \
     ArborTest, \
     TempDirTest
@@ -9,3 +10,9 @@ class AHFArborTest(TempDirTest, ArborTest):
     test_filename = "ahf_halos/snap_N64L16_000.parameter"
     num_data_files = 136
     tree_skip = 100
+
+class AHFNewArborTest(TempDirTest, ArborTest):
+    arbor_type = AHFNewArbor
+    test_filename = "AHF_100_tiny/GIZMO-NewMDCLUSTER_0047.snap_128.parameter"
+    num_data_files = 5
+    tree_skip = 10

--- a/tests/frontends/test_ahf.py
+++ b/tests/frontends/test_ahf.py
@@ -15,4 +15,4 @@ class AHFNewArborTest(TempDirTest, ArborTest):
     arbor_type = AHFNewArbor
     test_filename = "AHF_100_tiny/GIZMO-NewMDCLUSTER_0047.snap_128.parameter"
     num_data_files = 5
-    tree_skip = 10
+    tree_skip = 100

--- a/ytree/data_structures/arbor.py
+++ b/ytree/data_structures/arbor.py
@@ -1204,7 +1204,7 @@ class CatalogArbor(Arbor):
                     tree_node.data_file = data_file
                     batch[it] = tree_node
 
-                    if collect_missed_connections:
+                    if self._has_uids:
                         all_dict[my_uid] = tree_node
 
                     if root:
@@ -1241,13 +1241,16 @@ class CatalogArbor(Arbor):
         pbar.finish()
 
         if self._has_uids:
-            for mcon in missed_connections:
-                my_desc_uid = mcon._desc_uid
-                my_root = all_dict[my_desc_uid]
-                delattr(mcon, "_desc_uid")
-                if my_root._ancestors is None:
-                    my_root._ancestors = []
-                my_root._ancestors.append(mcon)
+            for node in missed_connections:
+                my_desc_uid = node._desc_uid
+                my_desc = all_dict[my_desc_uid]
+                delattr(node, "_desc_uid")
+
+                node._descendent = my_desc
+                node.root = my_desc.root
+                if my_desc._ancestors is None:
+                    my_desc._ancestors = []
+                my_desc._ancestors.append(node)
 
         self._trees = np.array(trees)
         self._size = self._trees.size

--- a/ytree/frontends/ahf/__init__.py
+++ b/ytree/frontends/ahf/__init__.py
@@ -14,4 +14,5 @@ amiga halo finder frontend
 #-----------------------------------------------------------------------------
 
 from ytree.frontends.ahf.arbor import \
-    AHFArbor
+    AHFArbor, \
+    AHFNewArbor

--- a/ytree/frontends/ahf/arbor.py
+++ b/ytree/frontends/ahf/arbor.py
@@ -120,10 +120,10 @@ class AHFArbor(CatalogArbor):
         self.data_files.reverse()
 
     def _get_file_index(self, f):
-        reg = re.search(rf"{self._prefix}(\d+).+{self._suffix}$", self.filename)
+        reg = re.search(rf"{self._prefix}(\d+){self._suffix}$", f)
         if not reg:
             raise RuntimeError(
-                f"Could not locate index within file: {self.filename}.")
+                f"Could not locate index within file: {f}.")
         return int(reg.groups()[0])
 
     @classmethod

--- a/ytree/frontends/ahf/arbor.py
+++ b/ytree/frontends/ahf/arbor.py
@@ -24,6 +24,7 @@ from ytree.frontends.ahf.fields import \
 from ytree.frontends.ahf.io import \
     AHFDataFile
 from ytree.frontends.ahf.misc import \
+    get_crm_filename, \
     parse_AHF_file
 from unyt.unit_registry import \
     UnitRegistry
@@ -135,4 +136,30 @@ class AHFArbor(CatalogArbor):
         fn = args[0]
         if not fn.endswith(self._suffix):
             return False
+
+        mtree_fn = get_crm_filename(fn)
+        if mtree_fn is not None and os.path.exists(mtree_fn):
+            return False
+
+        return True
+
+class AHFNewArbor(AHFArbor):
+    """
+    Arbor for a newer version of Amiga Halo Finder data.
+    """
+
+    @classmethod
+    def _is_valid(self, *args, **kwargs):
+        """
+        File must end in .AHF_halos and have an associated
+        .parameter file.
+        """
+        fn = args[0]
+        if not fn.endswith(self._suffix):
+            return False
+
+        mtree_fn = get_crm_filename(fn, self._suffix)
+        if mtree_fn is None or not os.path.exists(mtree_fn):
+            return False
+
         return True

--- a/ytree/frontends/ahf/arbor.py
+++ b/ytree/frontends/ahf/arbor.py
@@ -55,9 +55,17 @@ class AHFArbor(CatalogArbor):
         pars = {"simu.omega0": "omega_matter",
                 "simu.lambda0": "omega_lambda",
                 "simu.boxsize": "box_size"}
-        log_filename = self.log_filename \
-          if self.log_filename is not None else df.filekey + ".log"
-        if os.path.exists(log_filename):
+
+        if self.log_filename is None:
+            fns = glob.glob(df.filekey + "*.log")
+            if fns:
+                log_filename = fns[0]
+            else:
+                log_filename = None
+        else:
+            log_filename = self.log_filename
+
+        if log_filename is not None and os.path.exists(log_filename):
             vals = parse_AHF_file(log_filename, pars, sep=":")
             for attr in ["omega_matter",
                          "omega_lambda"]:

--- a/ytree/frontends/ahf/arbor.py
+++ b/ytree/frontends/ahf/arbor.py
@@ -165,16 +165,7 @@ class AHFNewArbor(AHFArbor):
 
     def _parse_parameter_file(self):
         super()._parse_parameter_file()
-        self._initialize_crm_table()
-
-    def _initialize_crm_table(self):
         self._crm_filename = get_crm_filename(self.filename, self._suffix)
-        self._crm_table = {}
-        with open(self._crm_filename, mode="r") as f:
-            for i in range(3):
-                line = f.readline()
-            self._crm_max = int(line.split()[2])
-            self._crm_table[self._crm_max] = f.tell()
 
     def _plant_trees(self):
         if self.is_planted:

--- a/ytree/frontends/ahf/fields.py
+++ b/ytree/frontends/ahf/fields.py
@@ -70,3 +70,23 @@ class AHFFieldInfo(FieldInfoContainer):
         ('uid', id_type),
         ('desc_uid', id_type)
     )
+
+class AHFNewFieldInfo(AHFFieldInfo):
+    alias_fields = (
+        ("halo_id", "ID", None),
+        ("uid", "ID", None),
+        ("desc_uid", "desc_id", None),
+        ("mass", "Mvir", m_unit),
+        ("virial_mass", "Mvir", m_unit),
+        ("position_x", "Xc", p_unit),
+        ("position_y", "Yc", p_unit),
+        ("position_z", "Zc", p_unit),
+        ("velocity_x", "VXc", v_unit),
+        ("velocity_y", "VYc", v_unit),
+        ("velocity_z", "VZc", v_unit),
+        ("virial_radius", "Rvir", p_unit),
+        ("velocity_dispersion", "sigV", v_unit),
+        ("spin_parameter", "lambda", None),
+        ("kinetic_energy", "Ekin", "Msun/h * (km/s)**2"),
+        ("potential_energy", "Epot", "Msun/h * (km/s)**2"),
+    )

--- a/ytree/frontends/ahf/fields.py
+++ b/ytree/frontends/ahf/fields.py
@@ -48,7 +48,7 @@ class AHFFieldInfo(FieldInfoContainer):
     )
 
     alias_fields = (
-        ("halo_id", "ID", None),
+        ("halo_id", "ID", ""),
         ("mass", "Mvir", m_unit),
         ("virial_mass", "Mvir", m_unit),
         ("position_x", "Xc", p_unit),
@@ -59,7 +59,7 @@ class AHFFieldInfo(FieldInfoContainer):
         ("velocity_z", "VZc", v_unit),
         ("virial_radius", "Rvir", p_unit),
         ("velocity_dispersion", "sigV", v_unit),
-        ("spin_parameter", "lambda", None),
+        ("spin_parameter", "lambda", ""),
         ("kinetic_energy", "Ekin", "Msun/h * (km/s)**2"),
         ("potential_energy", "Epot", "Msun/h * (km/s)**2"),
     )
@@ -73,8 +73,8 @@ class AHFFieldInfo(FieldInfoContainer):
 
 class AHFNewFieldInfo(AHFFieldInfo):
     alias_fields = (
-        ("uid", "ID", None),
-        ("desc_uid", "desc_id", None),
+        ("uid", "ID", ""),
+        ("desc_uid", "desc_id", ""),
         ("mass", "Mvir", m_unit),
         ("virial_mass", "Mvir", m_unit),
         ("position_x", "Xc", p_unit),
@@ -85,7 +85,7 @@ class AHFNewFieldInfo(AHFFieldInfo):
         ("velocity_z", "VZc", v_unit),
         ("virial_radius", "Rvir", p_unit),
         ("velocity_dispersion", "sigV", v_unit),
-        ("spin_parameter", "lambda", None),
+        ("spin_parameter", "lambda", ""),
         ("kinetic_energy", "Ekin", "Msun/h * (km/s)**2"),
         ("potential_energy", "Epot", "Msun/h * (km/s)**2"),
     )

--- a/ytree/frontends/ahf/fields.py
+++ b/ytree/frontends/ahf/fields.py
@@ -73,7 +73,6 @@ class AHFFieldInfo(FieldInfoContainer):
 
 class AHFNewFieldInfo(AHFFieldInfo):
     alias_fields = (
-        ("halo_id", "ID", None),
         ("uid", "ID", None),
         ("desc_uid", "desc_id", None),
         ("mass", "Mvir", m_unit),

--- a/ytree/frontends/ahf/io.py
+++ b/ytree/frontends/ahf/io.py
@@ -20,7 +20,6 @@ import re
 import weakref
 
 from ytree.frontends.ahf.misc import \
-    get_crm_table_value, \
     parse_AHF_file
 from ytree.data_structures.io import \
     CatalogDataFile

--- a/ytree/frontends/ahf/io.py
+++ b/ytree/frontends/ahf/io.py
@@ -27,16 +27,25 @@ from ytree.utilities.io import \
     f_text_block
 
 class AHFDataFile(CatalogDataFile):
+    _redshift_precision = 3
+
     def __init__(self, filename, arbor):
         self.filename = filename
         self.filekey = self.filename[:self.filename.rfind(".parameter")]
         self._parse_header()
 
-        res = re.search(r"\.z\d\.\d{3}", self.filekey)
+        rprec = self._redshift_precision
+        rstr = r"\.z\d\.\d\{%d\}" % rprec
+        res = re.search(rstr, self.filekey)
         if res:
             self.data_filekey = self.filekey[:res.end()]
         else:
-            self.data_filekey = f"{self.filekey}.z{self.redshift:.03f}"
+            minz = 10**-rprec
+            if abs(self.redshift) < minz:
+                self.redshift = 0
+            zfmt = f".0{rprec}f"
+            my_z = format(self.redshift, zfmt)
+            self.data_filekey = f"{self.filekey}.z{my_z}"
 
         self.halos_filename = self.data_filekey + ".AHF_halos"
         self.mtree_filename = self.data_filekey + ".AHF_mtree"

--- a/ytree/frontends/ahf/io.py
+++ b/ytree/frontends/ahf/io.py
@@ -307,36 +307,8 @@ class AHFNewDataFile(AHFDataFile):
         Read the CRMratio2 file.
         """
 
-        self._links = desc_dict = {}
-        if self._catalog_index == self.arbor._crm_max:
-            return
-
-        ci = self._catalog_index + 1
-        ct = self.arbor._crm_table
-        f = open(self.arbor._crm_filename, mode="r")
-        loc = get_crm_table_value(f, ci, ct)
-        if loc is None:
-            return
-
-        f.seek(loc)
-        for line, loc in f_text_block(f):
-            if line.startswith("END"):
-                break
-            online = line.split()
-            thing = online[0]
-            if len(online) == 2:
-                cid = int(thing[:-12])
-                if cid < ci:
-                    ct[cid] = loc
-                    break
-                my_descid = int(thing)
-                continue
-
-            # Assume the ID field is in order and there are none missing.
-            # That is, assume we can use the uid to get the array index.
-            my_id = int(thing)
-            desc_dict[my_id] = my_descid
-        f.close()
+    def _compute_links(self):
+        self.arbor._compute_links()
 
     def _get_mtree_fields(self, tfields, dtypes, field_data):
         if not tfields:

--- a/ytree/frontends/ahf/io.py
+++ b/ytree/frontends/ahf/io.py
@@ -29,12 +29,12 @@ from ytree.utilities.misc import fround
 
 class AHFDataFile(CatalogDataFile):
     _redshift_precision = 3
-    _data_suffix = ".AHF_halos"
 
     def __init__(self, filename, arbor):
+        self.arbor = weakref.proxy(arbor)
         self.filename = filename
         self._catalog_index = arbor._get_file_index(filename)
-        self.filekey = self.filename[:self.filename.rfind(".parameter")]
+        self.filekey = self.filename[:self.filename.rfind(self.arbor._par_suffix)]
         self._parse_header()
 
         rprec = self._redshift_precision
@@ -47,22 +47,21 @@ class AHFDataFile(CatalogDataFile):
             for inc in [0, -10**-rprec]:
                 my_z = format(fround(self.redshift, decimals=rprec) + inc, zfmt)
                 fkey = f"{self.filekey}.z{my_z}"
-                if os.path.exists(fkey + self._data_suffix):
+                if os.path.exists(fkey + self.arbor._data_suffix):
                     self.data_filekey = fkey
                     break
 
             if not hasattr(self, "data_filekey"):
                 raise FileNotFoundError(
-                    f"Cannot find data file: {fkey + self._data_suffix}.")
+                    f"Cannot find data file: {fkey + self.arbor._data_suffix}.")
 
-        self.halos_filename = self.data_filekey + ".AHF_halos"
-        self.mtree_filename = self.data_filekey + ".AHF_mtree"
+        self.halos_filename = self.data_filekey + self.arbor._data_suffix
+        self.mtree_filename = self.data_filekey + self.arbor._mtree_suffix
         if not os.path.exists(self.mtree_filename):
             self.mtree_filename = None
         self.fh = None
         self._parse_data_header()
         self.offsets = None
-        self.arbor = weakref.proxy(arbor)
 
     def _parse_data_header(self):
         """

--- a/ytree/frontends/ahf/io.py
+++ b/ytree/frontends/ahf/io.py
@@ -316,7 +316,6 @@ class AHFNewDataFile(AHFDataFile):
 
         ci = self._catalog_index + 1
         ct = self.arbor._crm_table
-        cistr = str(ci)
         f = open(self.arbor._crm_filename, mode="r")
         loc = get_crm_table_value(f, ci, ct)
         if loc is None:

--- a/ytree/frontends/ahf/misc.py
+++ b/ytree/frontends/ahf/misc.py
@@ -13,6 +13,20 @@ AHFArbor miscellany
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
+import os
+import re
+
+def get_crm_filename(filename, suffix):
+    # Searching for <keyword>.something.<suffix>
+    res = re.search(f"([^\.]+)\.[^\.]+{suffix}$", filename)
+    if not res:
+        return None
+
+    filekey = res.groups()[0]
+    ddir = os.path.dirname(filekey)
+    bname = os.path.basename(filekey)
+    return os.path.join(ddir, f"MergerTree_{bname}.txt-CRMratio2")
+
 def parse_AHF_file(filename, pars, sep=None):
     """
     Parse an AHF log or parameter file.

--- a/ytree/frontends/ahf/misc.py
+++ b/ytree/frontends/ahf/misc.py
@@ -21,7 +21,7 @@ from ytree.utilities.io import f_text_block
 
 def get_crm_filename(filename, suffix):
     # Searching for <keyword>.something.<suffix>
-    res = re.search(f"([^\.]+)\.[^\.]+{suffix}$", filename)
+    res = re.search(rf"([^\.]+)\.[^\.]+{suffix}$", filename)
     if not res:
         return None
 
@@ -49,12 +49,12 @@ def get_crm_table_value(f, index, table):
         online = line.split()
         thing = online[0]
         if len(online) == 2:
-                cid = int(thing[:-12])
-                if cid < current_cid:
-                    table[cid] = loc
-                    current_cid = cid
-                    if cid == index:
-                        return table[index]
+            cid = int(thing[:-12])
+            if cid < current_cid:
+                table[cid] = loc
+                current_cid = cid
+                if cid == index:
+                    return table[index]
 
 def parse_AHF_file(filename, pars, sep=None):
     """

--- a/ytree/frontends/ahf/misc.py
+++ b/ytree/frontends/ahf/misc.py
@@ -13,11 +13,8 @@ AHFArbor miscellany
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-import numpy as np
 import os
 import re
-
-from ytree.utilities.io import f_text_block
 
 def get_crm_filename(filename, suffix):
     # Searching for <keyword>.something.<suffix>
@@ -29,32 +26,6 @@ def get_crm_filename(filename, suffix):
     ddir = os.path.dirname(filekey)
     bname = os.path.basename(filekey)
     return os.path.join(ddir, f"MergerTree_{bname}.txt-CRMratio2")
-
-def get_crm_table_value(f, index, table):
-    if index in table:
-        return table[index]
-
-    indices = np.array(list(table.keys()))
-    istart = min(indices[indices > index])
-    if table[istart] is None:
-        table[index] = None
-        return table[index]
-
-    f.seek(table[istart])
-    current_cid = istart
-    for line, loc in f_text_block(f):
-        if line.startswith("END"):
-            table[index] = None
-            return table[index]
-        online = line.split()
-        thing = online[0]
-        if len(online) == 2:
-            cid = int(thing[:-12])
-            if cid < current_cid:
-                table[cid] = loc
-                current_cid = cid
-                if cid == index:
-                    return table[index]
 
 def parse_AHF_file(filename, pars, sep=None):
     """

--- a/ytree/frontends/ahf/misc.py
+++ b/ytree/frontends/ahf/misc.py
@@ -13,20 +13,6 @@ AHFArbor miscellany
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-import os
-import re
-
-def get_crm_filename(filename, suffix):
-    # Searching for <keyword>.something.<suffix>
-    res = re.search(rf"([^\.]+)\.[^\.]+{suffix}$", filename)
-    if not res:
-        return None
-
-    filekey = res.groups()[0]
-    ddir = os.path.dirname(filekey)
-    bname = os.path.basename(filekey)
-    return os.path.join(ddir, f"MergerTree_{bname}.txt-CRMratio2")
-
 def parse_AHF_file(filename, pars, sep=None):
     """
     Parse an AHF log or parameter file.

--- a/ytree/utilities/misc.py
+++ b/ytree/utilities/misc.py
@@ -1,0 +1,23 @@
+"""
+miscellaneous utilities
+
+
+
+"""
+
+#-----------------------------------------------------------------------------
+# Copyright (c) ytree development team. All rights reserved.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+import numpy as np
+
+def fround(val, decimals=0):
+    """
+    Round 0.5 up to 1 and so on.
+    """
+    fac = 10**decimals
+    return np.floor(val * fac + 0.5) / fac


### PR DESCRIPTION
<!--Thanks for issuing a PR! To help us review, please provide a
description below. Please see the development guide at
http://ytree.readthedocs.io/en/latest/Developing.html for tips.-->

<!--If possible, please issue your PR from a new branch that is
not the master branch.-->

This adds support for a new AHF format where the entire tree structure is stored in a single ascii file rather than one mtree file per catalog. This is a duplicate to PR #151, but I couldn't get the ci testing to update there.

## PR Summary

<!--Describe the changes. Mention any relevant open issues.
If you need help with anything, let us know!-->

## PR Checklist

<!--Some, none, or all of these may apply. Remove if unnecessary.-->

- [ ] Code passes tests.
- [ ] New features are documented with docstrings and narrative docs.
- [ ] Tests added for fixed bugs or new features.

<!--Thanks!-->
