### PR TITLE
Replace deprecated unyt.uconcatenate function

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(name="ytree",
           'h5py',
           "more_itertools>=8.4",
           'numpy',
-          'unyt',
+          'unyt>=3.0.1',
           'yt>=4.2',
       ],
       extras_require={

--- a/tests/test_yt_selection.py
+++ b/tests/test_yt_selection.py
@@ -15,7 +15,6 @@ tests for yt frontend and selection functions
 
 import numpy as np
 from numpy.testing import assert_raises
-from unyt import uconcatenate
 import ytree
 
 from ytree.utilities.testing import \
@@ -49,7 +48,7 @@ class YTSelectionTest(TempDirTest):
         for field, units in zip(["mass", "redshift"], ["Msun", ""]):
             yt_data = ad["halos", field].to(units)
             yt_data.sort()
-            ytree_data = uconcatenate([t["forest", field] for t in a])
+            ytree_data = np.concatenate([t["forest", field] for t in a])
             ytree_data.sort()
             assert_array_rel_equal(yt_data, ytree_data, decimals=5)
 
@@ -60,8 +59,8 @@ class YTSelectionTest(TempDirTest):
 
         sp = ds.sphere(0.5*ds.domain_center, (20, "Mpc/h"))
 
-        ytree_pos = uconcatenate([t["forest", "position"] for t in a])
-        ytree_mass = uconcatenate([t["forest", "mass"] for t in a])
+        ytree_pos = np.concatenate([t["forest", "position"] for t in a])
+        ytree_mass = np.concatenate([t["forest", "mass"] for t in a])
         r = a.quan(sp.radius.to("unitary"))
         c = a.arr(sp.center.to("unitary"))
         ytree_r = np.sqrt(((ytree_pos - c)**2).sum(axis=1))

--- a/ytree/data_structures/io.py
+++ b/ytree/data_structures/io.py
@@ -16,7 +16,6 @@ FieldIO class and member functions
 from collections import defaultdict
 import numpy as np
 import os
-from unyt import uconcatenate
 import weakref
 
 from ytree.utilities.exceptions import \
@@ -264,7 +263,7 @@ class DefaultRootFieldIO(FieldIO):
             fields=fields, dtypes=my_dtypes, root_only=True)
 
         field_data = \
-          dict((field, uconcatenate([fvals[field] for fvals in rvals]))
+          dict((field, np.concatenate([fvals[field] for fvals in rvals]))
                for field in fields)
 
         return field_data

--- a/ytree/data_structures/save_arbor.py
+++ b/ytree/data_structures/save_arbor.py
@@ -9,7 +9,6 @@ import json
 import numpy as np
 import os
 import types
-from unyt import uconcatenate
 
 from yt.frontends.ytdata.utilities import save_as_dataset
 from ytree.utilities.io import ensure_dir
@@ -233,7 +232,7 @@ def save_data_file(arbor, filename, fields, tree_group,
             my_ftypes = main_ftypes
 
         my_ftypes[fieldname] = "data"
-        my_fdata[fieldname]  = uconcatenate(
+        my_fdata[fieldname]  = np.concatenate(
             [node.field_data[field] if node.is_root else node["tree", field]
              for node in tree_group])
         root_field_data[field].append(my_fdata[fieldname][my_tree_start])
@@ -303,7 +302,7 @@ def save_header_file(arbor, filename, fields, root_field_data,
           dict((key, fi[key])
                for key in ["units", "description"]
                if key in fi)
-        my_rdata[fieldname] = uconcatenate(root_field_data[field])
+        my_rdata[fieldname] = np.concatenate(root_field_data[field])
         my_rtypes[fieldname] = "data"
 
     # all saved trees will be roots

--- a/ytree/frontends/gadget4/io.py
+++ b/ytree/frontends/gadget4/io.py
@@ -17,8 +17,6 @@ import h5py
 import numpy as np
 import re
 
-from unyt import uconcatenate
-
 from ytree.data_structures.io import \
     DataFile, \
     TreeFieldIO
@@ -115,7 +113,7 @@ class Gadget4TreeFieldIO(TreeFieldIO):
                 data_file.close()
 
         for field in field_data:
-            field_data[field] = uconcatenate(field_data[field])
+            field_data[field] = np.concatenate(field_data[field])
 
         if afields:
             field_data.update(self._get_arbor_fields(


### PR DESCRIPTION
## PR Summary

This replaces the deprecated `unyt.uconcatenate` with `np.concatenate`, as per the direction of unyt 3.0.

## PR Checklist

<!--Some, none, or all of these may apply. Remove if unnecessary.-->

- [ ] Code passes tests.
- [ ] New features are documented with docstrings and narrative docs.
- [ ] Tests added for fixed bugs or new features.

<!--Thanks!-->
