### PR TITLE
Add resource_class for testing and remove daily tests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,8 @@ commands:
       coverage:
         type: integer
         default: 0
+      pytestkwargs:
+        type: string
 
     steps:
       - run:
@@ -95,7 +97,7 @@ commands:
             source $BASH_ENV
             source $HOME/venv/bin/activate
             TESTFILES=$(circleci tests glob "tests/*.py" "tests/frontends/*.py" | circleci tests split --split-by=timings)
-            pytest --cov=ytree --junitxml=test-results/junit.xml $TESTFILES
+            pytest --cov=ytree --junitxml=test-results/junit.xml << parameters.pytestkwargs >> $TESTFILES
             python fix-junit.py test-results/junit.xml
             if [ << parameters.coverage >> == 1 ]; then
                 # code coverage report
@@ -128,8 +130,8 @@ executors:
 
 jobs:
   tests:
-    resource_class: large
-    parallelism: 2
+    resource_class: medium
+    parallelism: 4
     parameters:
       tag:
         type: string
@@ -140,6 +142,8 @@ jobs:
       coverage:
         type: integer
         default: 0
+      pytestkwargs:
+        type: string
     executor:
       name: python
       tag: << parameters.tag >>
@@ -182,6 +186,7 @@ jobs:
 
       - run-tests:
           coverage: << parameters.coverage >>
+          pytestkwargs: << parameters.pytestkwargs >>
 
   docs-test:
     resource_class: small
@@ -221,18 +226,21 @@ workflows:
            name: "Python 3.9 tests"
            tag: "3.9.20"
            ytdev: 0
+           pytestkwargs: "--serialonly"
 
        - tests:
            name: "Python 3.12 tests"
            tag: "3.12.7"
            coverage: 1
            ytdev: 1
+           pytestkwargs: "--serialonly"
 
        - tests:
            name: "Python 3.12 tests"
            tag: "3.12.7"
            coverage: 0
            ytdev: 0
+           pytestkwargs: "--serialonly"
 
        - docs-test:
            name: "Test docs build"
@@ -252,12 +260,14 @@ workflows:
            name: "Python 3.9 tests"
            tag: "3.9.20"
            ytdev: 0
+           pytestkwargs: "--serialonly"
 
        - tests:
            name: "Python 3.12 tests"
            tag: "3.12.7"
            coverage: 0
            ytdev: 1
+           pytestkwargs: "--serialonly"
 
        - docs-test:
            name: "Test docs build"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,17 +269,6 @@ workflows:
        - tests:
            requires:
              - linting
-           name: "Python 3.12 parallel tests"
-           tag: "3.12.7"
-           coverage: 1
-           ytdev: 1
-           pytestkwargs: "--parallelonly"
-           parallelism: 1
-           resource_class: large
-
-       - tests:
-           requires:
-             - linting
            name: "Python 3.12 tests"
            tag: "3.12.7"
            coverage: 0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,7 +149,6 @@ jobs:
       tag: << parameters.tag >>
 
   tests:
-    resource_class: medium
     parameters:
       tag:
         type: string
@@ -157,6 +156,9 @@ jobs:
       parallelism:
         type: integer
         default: 4
+      resource_class:
+        type: string
+        default: medium
       ytdev:
         type: integer
         default: 0
@@ -166,6 +168,7 @@ jobs:
       pytestkwargs:
         type: string
     parallelism: << parameters.parallelism >>
+    resource_class: << parameters.resource_class >>
     executor:
       name: python
       tag: << parameters.tag >>
@@ -262,6 +265,17 @@ workflows:
            coverage: 1
            ytdev: 1
            pytestkwargs: "--serialonly"
+
+       - tests:
+           requires:
+             - linting
+           name: "Python 3.12 parallel tests"
+           tag: "3.12.7"
+           coverage: 1
+           ytdev: 1
+           pytestkwargs: "--parallelonly"
+           parallelism: 1
+           resource_class: large
 
        - tests:
            requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,8 +76,12 @@ commands:
       - run:
           name: "Lint."
           command: |
+            if [ ! -d $HOME/venv ]; then
+                python3 -m venv $HOME/venv
+            fi
             source $BASH_ENV
             source $HOME/venv/bin/activate
+            pip install flake8
             flake8 tests ytree doc/source/examples
 
   run-tests:
@@ -129,6 +133,21 @@ executors:
       - image: cimg/python:<< parameters.tag >>
 
 jobs:
+  linting:
+    resource_class: small
+    parameters:
+      tag:
+        type: string
+        default: latest
+    working_directory: ~/ytree
+    steps:
+      - checkout
+      - set-env
+      - lint
+    executor:
+      name: python
+      tag: << parameters.tag >>
+
   tests:
     resource_class: medium
     parallelism: 4
@@ -169,8 +188,6 @@ jobs:
             - ~/.cache/pip
             - ~/venv
             - ~/yt-git
-
-      - lint
 
       - restore_cache:
           name: "Restore test data cache."
@@ -222,13 +239,21 @@ workflows:
 
    normal-tests:
      jobs:
+       - linting:
+           name: "linting"
+           tag: "3.12.7"
+
        - tests:
+           requires:
+             - linting
            name: "Python 3.9 tests"
            tag: "3.9.20"
            ytdev: 0
            pytestkwargs: "--serialonly"
 
        - tests:
+           requires:
+             - linting
            name: "Python 3.12 tests"
            tag: "3.12.7"
            coverage: 1
@@ -236,6 +261,8 @@ workflows:
            pytestkwargs: "--serialonly"
 
        - tests:
+           requires:
+             - linting
            name: "Python 3.12 tests"
            tag: "3.12.7"
            coverage: 0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,11 +150,13 @@ jobs:
 
   tests:
     resource_class: medium
-    parallelism: 4
     parameters:
       tag:
         type: string
         default: latest
+      parallelism:
+        type: integer
+        default: 4
       ytdev:
         type: integer
         default: 0
@@ -163,6 +165,7 @@ jobs:
         default: 0
       pytestkwargs:
         type: string
+    parallelism: << parameters.parallelism >>
     executor:
       name: python
       tag: << parameters.tag >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,8 @@ executors:
 
 jobs:
   tests:
-    parallelism: 4
+    resource_class: large
+    parallelism: 2
     parameters:
       tag:
         type: string
@@ -183,6 +184,7 @@ jobs:
           coverage: << parameters.coverage >>
 
   docs-test:
+    resource_class: small
     parameters:
       tag:
         type: string
@@ -236,21 +238,6 @@ workflows:
            name: "Test docs build"
            tag: "3.12.7"
            ytdev: 0
-
-   daily:
-     triggers:
-       - schedule:
-           cron: "0 0 * * *"
-           filters:
-            branches:
-              only:
-                - main
-     jobs:
-       - tests:
-           name: "Python 3.12 tests"
-           tag: "3.12.7"
-           coverage: 0
-           ytdev: 1
 
    weekly:
      triggers:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,5 +1,8 @@
 version: 2
 
+sphinx:
+  configuration: doc/source/conf.py
+
 build:
   os: "ubuntu-20.04"
   tools:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,30 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--parallelonly", action="store_true", default=False,
+        help="run only parallel tests"
+    )
+    parser.addoption(
+        "--serialonly", action="store_true", default=False,
+        help="run only serial tests"
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "parallel: test uses parallelism")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--parallelonly"):
+        skip_serial = pytest.mark.skip(reason="only running parallel tests")
+        for item in items:
+            if "parallel" not in item.keywords:
+                item.add_marker(skip_serial)
+
+    if config.getoption("--serialonly"):
+        skip_parallel = pytest.mark.skip(reason="only running serial tests")
+        for item in items:
+            if "parallel" in item.keywords:
+                item.add_marker(skip_parallel)

--- a/tests/test_yt_selection.py
+++ b/tests/test_yt_selection.py
@@ -26,10 +26,20 @@ from ytree.yt_frontend import YTreeDataset
 CTG = "tiny_ctrees/locations.dat"
 
 class YTSelectionTest(TempDirTest):
+    """
+    Test class for selecting halos with yt.
+    """
+
+    _setup = False
+    def setUp(self):
+        super().setUp()
+        self._setup = True
 
     _arbor = None
     @property
     def arbor(self):
+        if not self._setup:
+            return
         if self._arbor is not None:
             return self._arbor
 

--- a/ytree/utilities/testing.py
+++ b/ytree/utilities/testing.py
@@ -20,6 +20,7 @@ from numpy.testing import \
     assert_almost_equal, \
     assert_array_equal
 import os
+import pytest
 import shutil
 import subprocess
 import sys
@@ -91,6 +92,7 @@ class ParallelTest:
             assert_array_equal(tree[group, "test_field"], 2 * tree[group, "mass"])
 
     @skipIf(MPI is None, "mpi4py not installed")
+    @pytest.mark.parallel
     def test_parallel(self):
 
         for i, my_args in enumerate(self.arg_sets):
@@ -130,6 +132,7 @@ class ExampleScriptTest:
     output_files = ()
     ncores = 1
 
+    @pytest.mark.parallel
     def test_example(self):
         if self.script_filename is None:
             return

--- a/ytree/utilities/testing.py
+++ b/ytree/utilities/testing.py
@@ -82,7 +82,7 @@ class ParallelTest:
     base_filename = "tiny_ctrees/locations.dat"
     test_filename = "test_arbor/test_arbor.h5"
     test_script = None
-    ncores = 4
+    ncores = 2
 
     def check_values(self, arbor, my_args):
         group = my_args[1]

--- a/ytree/utilities/testing.py
+++ b/ytree/utilities/testing.py
@@ -83,7 +83,7 @@ class ParallelTest:
     base_filename = "tiny_ctrees/locations.dat"
     test_filename = "test_arbor/test_arbor.h5"
     test_script = None
-    ncores = 2
+    ncores = 4
 
     def check_values(self, arbor, my_args):
         group = my_args[1]


### PR DESCRIPTION
Tests have been failing because the default resource class changed to only allow 2 processors instead of 4. We explicitly ask for the large class and remove the daily tests to cut down on resources.

Update: for whatever reason, circle just won't run the parallel tests anymore, always claiming it can't spawn processes even when they should be available. Whatever, I give up for now. I'll try to remember to test them locally from time to time.