### PR TITLE
Add ability to customize file naming conventions for AHF.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,13 +197,13 @@ jobs:
 
       - restore_cache:
           name: "Restore test data cache."
-          key: test-data-abernathy
+          key: test-data-abrego
 
       - download-test-data
 
       - save_cache:
           name: "Save test data cache."
-          key: test-data-abernathy
+          key: test-data-abrego
           paths:
             - ~/ytree_test
 

--- a/doc/source/Loading.rst
+++ b/doc/source/Loading.rst
@@ -15,12 +15,13 @@ There are two main ways that the `Amiga Halo Finder
 <http://popia.ft.uam.es/AHF/>`__ will output merger tree information.
 Most AHF outputs will contain a series of files (one per snapshot) linking
 a halo in that snapshot with its progenitors. These usually, but not always,
-have file names ending in ".AHF_mtree". *See below if these files have
-different names in your data.* The second way is to create a single file
-containing descendent/ancestor links for all halos from all snapshots. This
-file usually starts with "MergerTree\_" and ends with "-CRMratio2". As long as
-your data contains one of the above, everything should be fine even if the
-naming conventions are slightly different.
+have file names ending in ".AHF_mtree". See :ref:`ahf-naming` if these
+files have different names in your data. The second way is to create
+a single file containing descendent/ancestor links for all halos from
+all snapshots. This file usually starts with "MergerTree\_" and ends
+with "-CRMratio2". As long as your data contains one of the above,
+everything should be fine even if the naming conventions are slightly
+different.
 
 Both formats save a series of files associated with each
 snapshot. Parameters are stored in ".parameters" and ".log" files and
@@ -28,18 +29,18 @@ halo properties (i.e., all the fields) in ".AHF_halos" files. Make
 sure to keep all these files together in the same directory.
 
 If you have the one big file starting with "MergerTree\_" and ending
-with "-CRMratio2, use that to load the data.
+with "-CRMratio2", use that to load the data.
 
 .. code-block:: python
 
    >>> import ytree
    >>> a = ytree.load("AHF_100_tiny/MergerTree_GIZMO-NewMDCLUSTER_0047.txt-CRMratio2")
 
-`ytree` will then try to guess the naming convention for the parameter
-files based on the name of the one big file or on the available files
-ending in ".parameter." An exception will be raised if neither of
-these methods are able to locate a parameter file. If this is the
-case, provide one using the `parameter_filename` keyword.
+``ytree`` will then try to guess the naming convention for the
+parameter files based on the name of the one big file or on the
+available files ending in ".parameter". An exception will be raised if
+neither of these methods are able to locate a parameter file. If this
+is the case, provide one using the `parameter_filename` keyword.
 
 .. code-block:: python
 
@@ -55,6 +56,8 @@ If you don't have the one big file, then provide the name of the first
    >>> import ytree
    >>> a = ytree.load("ahf_halos/snap_N64L16_000.parameter",
    ...                hubble_constant=0.7)
+
+.. _ahf-naming:
 
 AHF data with different naming conventions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -120,7 +123,7 @@ like those described here.
              calculated instead of the tree. However, even in this case,
              only the tree is preserved in ``ytree``. See the `Amiga Halo
              Finder Documentation
-             <http://popia.ft.uam.es/AHF/Documentation.html>`_
+             <http://popia.ft.uam.es/AHF/files/AHF.pdf>`_
              for a discussion of the difference between graphs and trees.
 
 .. _load-ctrees:

--- a/doc/source/Loading.rst
+++ b/doc/source/Loading.rst
@@ -11,16 +11,44 @@ use the freely available :ref:`sample-data`.
 Amiga Halo Finder
 -----------------
 
-There are a couple data formats associated with the `Amiga Halo Finder
-<http://popia.ft.uam.es/AHF/>`__. Both formats save a series of files
-associated with each snapshot. Parameters are stored in ".parameters"
-and ".log" files and halo properties in ".AHF_halos" files. In the
-older format, descendent/ancestor links are stored in several
-".AHF_mtree" files, one per snapshot. In the newer format, all halo
-linking information is stored in a single file beginning with
-"MergerTree\_" and ending with "-CRMratio2". Make sure to keep all
-these files together in the same directory. To load, provide the name
-of the first ".parameter" file.
+There are two main ways that the `Amiga Halo Finder
+<http://popia.ft.uam.es/AHF/>`__ will output merger tree information.
+Most AHF outputs will contain a series of files (one per snapshot) linking
+a halo in that snapshot with its progenitors. These usually, but not always,
+have file names ending in ".AHF_mtree". *See below if these files have
+different names in your data.* The second way is to create a single file
+containing descendent/ancestor links for all halos from all snapshots. This
+file usually starts with "MergerTree\_" and ends with "-CRMratio2". As long as
+your data contains one of the above, everything should be fine even if the
+naming conventions are slightly different.
+
+Both formats save a series of files associated with each
+snapshot. Parameters are stored in ".parameters" and ".log" files and
+halo properties (i.e., all the fields) in ".AHF_halos" files. Make
+sure to keep all these files together in the same directory.
+
+If you have the one big file starting with "MergerTree\_" and ending
+with "-CRMratio2, use that to load the data.
+
+.. code-block:: python
+
+   >>> import ytree
+   >>> a = ytree.load("AHF_100_tiny/MergerTree_GIZMO-NewMDCLUSTER_0047.txt-CRMratio2")
+
+`ytree` will then try to guess the naming convention for the parameter
+files based on the name of the one big file or on the available files
+ending in ".parameter." An exception will be raised if neither of
+these methods are able to locate a parameter file. If this is the
+case, provide one using the `parameter_filename` keyword.
+
+.. code-block:: python
+
+   >>> import ytree
+   >>> a = ytree.load("AHF_100_tiny/MergerTree_GIZMO-NewMDCLUSTER_0047.txt-CRMratio2",
+                      parameter_filename="AHF_100_tiny/GIZMO-NewMDCLUSTER_0047.snap_128.parameter")
+
+If you don't have the one big file, then provide the name of the first
+".parameter" file.
 
 .. code-block:: python
 
@@ -28,13 +56,49 @@ of the first ".parameter" file.
    >>> a = ytree.load("ahf_halos/snap_N64L16_000.parameter",
    ...                hubble_constant=0.7)
 
-Alternatively, the "MergerTree\_" file can also be provided for the
-newer format.
+AHF data with different naming conventions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Occasionally, the naming conventions for various files will differ
+from the above. Sometimes, the arbor will appear to load correctly,
+but all the trees will appear as singular objects with no descendents
+or ancestors. Other times, you may see an error the first time you try
+to query a tree. Two known variations are:
+
+#. Different file prefixes for the halo catalog and merger tree
+   files. For example, one set of files starting with "AHF" and the
+   other starting with "MTREE".
+#. The mtree data in files not ending in ".AHF_mtree". In this case,
+   there still may be files with this suffix, but they may not contain
+   the data that ``ytree`` is looking for. The files needed for this
+   should look something like below:
+
+.. code-block::
+
+   #   HaloID(1)   HaloPart(2)  NumProgenitors(3)
+   #      SharedPart(1)    HaloID(2)   HaloPart(3)
+   0  29769  12
+     29221  0  29918
+     1652  17  1652
+     362  90  362
+
+In the example below, this data is located in files ending with
+".AHF_croco". The `name_config` keyword can be used to specify a
+dictionary of naming conventions:
 
 .. code-block:: python
 
    >>> import ytree
-   >>> a = ytree.load("AHF_100_tiny/MergerTree_GIZMO-NewMDCLUSTER_0047.txt-CRMratio2")
+   >>> a = ytree.load(
+   >>>     "B25_N256_CDM_1LPT/AHF.B25_N256_CDM_1LPT.snap_055.parameter",
+   >>>     name_config={"ahf_prefix": "AHF.B25_N256_CDM_1LPT",
+   >>>                  "mtree_prefix": "MTREE.B25_N256_CDM_1LPT.z39_adapt",
+   >>>                  "mtree_suffix": ".AHF_croco"})
+
+Valid entries for the `name_config` dictionary are "ahf\_prefix",
+"mtree\_prefix", and "mtree\_suffix". When using AHF to create merger
+trees, it is advisable to use settings that result in file layouts
+like those described here.
 
 .. note:: Four important notes about loading AHF data:
 

--- a/tests/frontends/test_ahf.py
+++ b/tests/frontends/test_ahf.py
@@ -16,3 +16,13 @@ class AHFNewArborTest(TempDirTest, ArborTest):
     test_filename = "AHF_100_tiny/GIZMO-NewMDCLUSTER_0047.snap_128.parameter"
     num_data_files = 5
     tree_skip = 100
+
+class AHFNameConfigArborTest(TempDirTest, ArborTest):
+    arbor_type = AHFArbor
+    test_filename = "B25_N256_CDM_1LPT/AHF.B25_N256_CDM_1LPT.snap_055.parameter"
+    load_kwargs = {"name_config":
+                       {"ahf_prefix": "AHF.B25_N256_CDM_1LPT",
+                        "mtree_prefix": "MTREE.B25_N256_CDM_1LPT.z39_adapt",
+                        "mtree_suffix": ".AHF_croco"}}
+    num_data_files = 2
+    tree_skip = 100

--- a/tests/frontends/test_ahf.py
+++ b/tests/frontends/test_ahf.py
@@ -1,6 +1,6 @@
 from ytree.frontends.ahf import \
     AHFArbor, \
-    AHFNewArbor
+    AHFCRMArbor
 from ytree.utilities.testing import \
     ArborTest, \
     TempDirTest
@@ -11,8 +11,8 @@ class AHFArborTest(TempDirTest, ArborTest):
     num_data_files = 136
     tree_skip = 100
 
-class AHFNewArborTest(TempDirTest, ArborTest):
-    arbor_type = AHFNewArbor
+class AHFCRMArborTest(TempDirTest, ArborTest):
+    arbor_type = AHFCRMArbor
     test_filename = "AHF_100_tiny/GIZMO-NewMDCLUSTER_0047.snap_128.parameter"
     num_data_files = 5
     tree_skip = 100

--- a/ytree/data_structures/arbor.py
+++ b/ytree/data_structures/arbor.py
@@ -131,10 +131,17 @@ class Arbor(metaclass=RegisteredArbor):
             fn = filename[0]
         else:
             fn = filename
-        self.parameter_filename = fn
+        self._set_parameter_filename(fn)
         self.basename = os.path.basename(fn)
         dn = os.path.dirname(fn)
         self.directory = dn if dn else '.'
+
+    def _set_parameter_filename(self, filename):
+        """
+        Set the name of the file from which to get metadata.
+        """
+
+        self.parameter_filename = filename
 
     def _parse_parameter_file(self):
         """

--- a/ytree/frontends/ahf/__init__.py
+++ b/ytree/frontends/ahf/__init__.py
@@ -15,4 +15,4 @@ amiga halo finder frontend
 
 from ytree.frontends.ahf.arbor import \
     AHFArbor, \
-    AHFNewArbor
+    AHFCRMArbor

--- a/ytree/frontends/ahf/arbor.py
+++ b/ytree/frontends/ahf/arbor.py
@@ -22,10 +22,10 @@ from ytree.data_structures.arbor import \
     CatalogArbor
 from ytree.frontends.ahf.fields import \
     AHFFieldInfo, \
-    AHFNewFieldInfo
+    AHFCRMFieldInfo
 from ytree.frontends.ahf.io import \
     AHFDataFile, \
-    AHFNewDataFile
+    AHFCRMDataFile
 from ytree.frontends.ahf.misc import \
     parse_AHF_file
 from unyt.unit_registry import \
@@ -44,7 +44,7 @@ class AHFArbor(CatalogArbor):
     _mtree_suffix = ".AHF_mtree"
     _par_suffix = ".parameter"
     _crm_prefix = "MergerTree_"
-    _crm_suffix = ".txt-CRMratio2"
+    _crm_suffix = "-CRMratio2"
     _field_info_class = AHFFieldInfo
     _data_file_class = AHFDataFile
 
@@ -196,14 +196,14 @@ class AHFArbor(CatalogArbor):
 
         return True
 
-class AHFNewArbor(AHFArbor):
+class AHFCRMArbor(AHFArbor):
     """
     Arbor for a newer version of Amiga Halo Finder data.
     """
 
     _has_uids = True
-    _field_info_class = AHFNewFieldInfo
-    _data_file_class = AHFNewDataFile
+    _field_info_class = AHFCRMFieldInfo
+    _data_file_class = AHFCRMDataFile
 
     def _set_paths(self, filename):
         super()._set_paths(filename)

--- a/ytree/frontends/ahf/arbor.py
+++ b/ytree/frontends/ahf/arbor.py
@@ -271,7 +271,7 @@ class AHFCRMArbor(AHFArbor):
         else:
             if not os.path.exists(self.crm_filename):
                 raise RuntimeError(
-                    f"Specified crm_filename does not exist: ",
+                    "Specified crm_filename does not exist: ",
                     self.crm_filename)
 
         if self.crm_filename is None:
@@ -283,7 +283,7 @@ class AHFCRMArbor(AHFArbor):
         else:
             if not os.path.exists(self.parameter_filename):
                 raise RuntimeError(
-                    f"Specified parameter_filename does not exist: ",
+                    "Specified parameter_filename does not exist: ",
                     self.parameter_filename)
 
         if self.parameter_filename is None:

--- a/ytree/frontends/ahf/arbor.py
+++ b/ytree/frontends/ahf/arbor.py
@@ -73,7 +73,7 @@ class AHFArbor(CatalogArbor):
         """
 
         for k, v in config.items():
-            if not re.match("\w+_(?:prefix|suffix)", k):
+            if not re.match(r"\w+_(?:prefix|suffix)", k):
                 raise ValueError(
                     f"name_config entry must end in either prefix or suffix: \"{k}\"")
             if not hasattr(self, f"_{k}"):

--- a/ytree/frontends/ahf/arbor.py
+++ b/ytree/frontends/ahf/arbor.py
@@ -38,6 +38,8 @@ class AHFArbor(CatalogArbor):
     Arbor for Amiga Halo Finder data.
     """
 
+    _ahf_prefix = None
+    _mtree_prefix = None
     _data_suffix = ".AHF_halos"
     _mtree_suffix = ".AHF_mtree"
     _par_suffix = ".parameter"
@@ -48,16 +50,37 @@ class AHFArbor(CatalogArbor):
 
     def __init__(self, filename, log_filename=None,
                  hubble_constant=1.0, box_size=None,
-                 omega_matter=None, omega_lambda=None):
+                 omega_matter=None, omega_lambda=None,
+                 name_config=None):
         self.unit_registry = UnitRegistry()
         self.log_filename = log_filename
         self.hubble_constant = hubble_constant
         self.omega_matter = omega_matter
         self.omega_lambda = omega_lambda
         self._box_size_user = box_size
+
+        if name_config is None:
+            name_config = {}
+        self._set_naming_conventions(name_config)
+
         self._file_pattern = re.compile(
             rf"(^.+[^0-9a-zA-Z]+)(\d+).*{self._par_suffix}$")
         super().__init__(filename)
+
+    def _set_naming_conventions(self, config):
+        """
+        Set some filename conventions.
+        """
+
+        for k, v in config.items():
+            if not re.match("\w+_(?:prefix|suffix)", k):
+                raise ValueError(
+                    f"name_config entry must end in either prefix or suffix: \"{k}\"")
+            if not hasattr(self, f"_{k}"):
+                raise ValueError(
+                    f"name_config entry not associated with a known attribute: \"{k}\"")
+
+            setattr(self, f"_{k}", v)
 
     def _is_crm_file(self, filename):
         return os.path.basename(filename).startswith(self._crm_prefix) and \

--- a/ytree/frontends/ahf/fields.py
+++ b/ytree/frontends/ahf/fields.py
@@ -73,7 +73,7 @@ class AHFFieldInfo(FieldInfoContainer):
         ('desc_uid', id_type)
     )
 
-class AHFNewFieldInfo(AHFFieldInfo):
+class AHFCRMFieldInfo(AHFFieldInfo):
     alias_fields = (
         ("uid", "ID", ""),
         ("desc_uid", "desc_id", ""),

--- a/ytree/frontends/ahf/fields.py
+++ b/ytree/frontends/ahf/fields.py
@@ -77,6 +77,7 @@ class AHFCRMFieldInfo(AHFFieldInfo):
     alias_fields = (
         ("uid", "ID", ""),
         ("desc_uid", "desc_id", ""),
+        ("mass", "Mhalo", m_unit),
         ("mass", "Mvir", m_unit),
         ("virial_mass", "Mvir", m_unit),
         ("position_x", "Xc", p_unit),

--- a/ytree/frontends/ahf/fields.py
+++ b/ytree/frontends/ahf/fields.py
@@ -26,6 +26,7 @@ id_type = np.int64
 
 class AHFFieldInfo(FieldInfoContainer):
     known_fields = (
+        ("Mhalo", m_unit),
         ("Mvir", m_unit),
         ("Xc", p_unit),
         ("Yc", p_unit),
@@ -49,6 +50,7 @@ class AHFFieldInfo(FieldInfoContainer):
 
     alias_fields = (
         ("halo_id", "ID", ""),
+        ("mass", "Mhalo", m_unit),
         ("mass", "Mvir", m_unit),
         ("virial_mass", "Mvir", m_unit),
         ("position_x", "Xc", p_unit),

--- a/ytree/frontends/ahf/io.py
+++ b/ytree/frontends/ahf/io.py
@@ -73,9 +73,15 @@ class AHFDataFile(CatalogDataFile):
         if self.arbor._ahf_prefix is None:
             mtree_key = self.data_filekey
         else:
+            # First, strip of the directory
+            mtree_key = re.sub(f"^{self.arbor.directory}{os.path.sep}", "",
+                               self.data_filekey)
+            # Now, substitute the prefixes
             mtree_key = re.sub(f"^{self.arbor._ahf_prefix}",
                                f"{self.arbor._mtree_prefix}",
-                               self.data_filekey)
+                               mtree_key)
+            # Return the directory
+            mtree_key = os.path.join(self.arbor.directory, mtree_key)
 
         self.mtree_filename = mtree_key + self.arbor._mtree_suffix
         if not os.path.exists(self.mtree_filename):

--- a/ytree/frontends/ahf/io.py
+++ b/ytree/frontends/ahf/io.py
@@ -323,7 +323,7 @@ class AHFDataFile(CatalogDataFile):
 
         return field_data
 
-class AHFNewDataFile(AHFDataFile):
+class AHFCRMDataFile(AHFDataFile):
     def _compute_links(self):
         """
         Read the CRMratio2 file.

--- a/ytree/frontends/ahf/io.py
+++ b/ytree/frontends/ahf/io.py
@@ -55,13 +55,31 @@ class AHFDataFile(CatalogDataFile):
                 raise FileNotFoundError(
                     f"Cannot find data file: {fkey + self.arbor._data_suffix}.")
 
-        self.halos_filename = self.data_filekey + self.arbor._data_suffix
-        self.mtree_filename = self.data_filekey + self.arbor._mtree_suffix
-        if not os.path.exists(self.mtree_filename):
-            self.mtree_filename = None
+        self._get_other_filenames()
         self.fh = None
         self._parse_data_header()
         self.offsets = None
+
+    def _get_other_filenames(self):
+        """
+        Figure out the various additional filenames we're going to need here.
+
+        If prefixes for the ahf and mtree files have been set, then we need to
+        look out for this and adjust.
+        """
+
+        self.halos_filename = self.data_filekey + self.arbor._data_suffix
+
+        if self.arbor._ahf_prefix is None:
+            mtree_key = self.data_filekey
+        else:
+            mtree_key = re.sub(f"^{self.arbor._ahf_prefix}",
+                               f"{self.arbor._mtree_prefix}",
+                               self.data_filekey)
+
+        self.mtree_filename = mtree_key + self.arbor._mtree_suffix
+        if not os.path.exists(self.mtree_filename):
+            self.mtree_filename = None
 
     def _parse_data_header(self):
         """


### PR DESCRIPTION
This addresses Issue #157. The key to the data shared in that PR is that it is using a different prefix and suffixes for some of the files, but they are generally still of the expected format. The easiest way I could think to deal with this is to allow the user to specify some of the naming conventions themselves in a dictionary at load. For example:

```
a = ytree.load(
    "AHF.B25_N256_CDM_1LPT.snap_055.parameter",
    name_config={"ahf_prefix": "AHF.B25_N256_CDM_1LPT",
                 "mtree_prefix": "MTREE.B25_N256_CDM_1LPT.z39_adapt",
                 "mtree_suffix": ".AHF_croco"})
```