### PR TITLE
Add documentation for helpful attributes and make cosmology calculator a cached_property

### DIFF
--- a/doc/source/Arbor.rst
+++ b/doc/source/Arbor.rst
@@ -55,6 +55,51 @@ Similar to `yt <http://yt-project.org/docs/dev/analyzing/fields.html>`__,
 ``ytree`` supports accessing fields by their native names as well as generalized
 aliases. For more information on fields in ``ytree``, see :ref:`fields`.
 
+Useful Arbor Attributes
+^^^^^^^^^^^^^^^^^^^^^^^
+
+A loaded arbor will have several helpful attributes.
+
+Creating Arrays and Quantities with Units
+"""""""""""""""""""""""""""""""""""""""""
+
+Support for unitful arrays and quantities is provided by the `unyt
+<https://unyt.readthedocs.io/en/stable/>`__ package. Arrays and
+quantities with symbolic units can be created directly with
+``unyt``. However, if done this way, they will not have access to any
+custom unit systems defined by a dataset. The
+:func:`~ytree.data_structures.arbor.Arbor.arr` and
+:func:`~ytree.data_structures.arbor.Arbor.quan` attributes allow one to
+create arrays and scalar quantities using the loaded arbor's unit
+system.
+
+.. code-block:: python
+
+   >>> my_array = a.arr([1, 2, 3], "Msun")
+   >>> my_quantity = a.quan(106, "km")
+
+Cosmology Calculations
+""""""""""""""""""""""
+
+If the dataset defines the cosmological parameters, `omega_matter`,
+`omega_lambda`, and `hubble_constant`, a
+:ref:`yt:cosmology-calculator` instance can be accessed via the
+:class:`~ytree.data_structures.arbor.Arbor.cosmology` attribute. This
+:class:`~yt.utilities.cosmology.Cosmology` instance will be configured
+with the previously mentioned cosmology parameters from the arbor as
+well as the arbor's internal unit system. If the necessary parameters
+are not defined within the dataset, the cosmology attribute will be
+unavailable.
+
+.. code-block:: python
+
+   >>> print (a.omega_matter, a.omega_lambda, a.hubble_constant)
+   0.285 0.715 0.695
+   >>> print (a.cosmology.comoving_radial_distance(0, 3).to("Mpc/h"))
+   4516.094598250588 Mpc/h
+   >>> print (a.cosmology.critical_density(0).to("Msun/Mpc**3"))
+   134065965531.17598 Msun/Mpc**3
+
 How many trees are there?
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -569,7 +614,7 @@ criteria, i.e., the criteria are combined with an AND operator.
    ...     above=[("redshift", 1)])
 
 For more complex search criteria, a cut region conditional string can be
-provided instead. These should be of the form described in :ref:`cut-regions`.
+provided instead. These should be of the form described in :ref:`yt:cut-regions`.
 These cannot not be given with any of the previously mentioned keywords.
 
 .. code-block:: python
@@ -631,7 +676,7 @@ to the data as a `yt <https://yt-project.org/>`__ dataset. This allows one to
 analyze the entire dataset using the full range of functionality provided by
 ``yt``. In this way, a merger tree dataset is very much like any particle dataset,
 where each particle represent a halo at a single time. For example, this makes it
-possible to select halos within :ref:`geometric data containers <data-objects>`,
+possible to select halos within :ref:`geometric data containers <yt:data-objects>`,
 like spheres or regions.
 
 .. code-block:: python

--- a/doc/source/Parallelism.rst
+++ b/doc/source/Parallelism.rst
@@ -12,7 +12,7 @@ can be used to parallelize analysis across multiple nodes of a
 distributed computing system.
 
 .. note:: Before reading this section, consult the
-   :ref:`parallel-computation` section of the ``yt`` documentation to
+   :ref:`yt:parallel-computation` section of the ``yt`` documentation to
    learn how to configure ``yt`` for running in parallel.
 
 Enabling Parallelism and Running in Parallel

--- a/doc/source/api_reference.rst
+++ b/doc/source/api_reference.rst
@@ -21,6 +21,9 @@ used to save the entire arbor or individual trees.
    ~ytree.data_structures.arbor.Arbor.add_analysis_field
    ~ytree.data_structures.arbor.Arbor.add_derived_field
    ~ytree.data_structures.arbor.Arbor.add_vector_field
+   ~ytree.data_structures.arbor.Arbor.arr
+   ~ytree.data_structures.arbor.Arbor.cosmology
+   ~ytree.data_structures.arbor.Arbor.quan
    ~ytree.data_structures.arbor.Arbor.save_arbor
    ~ytree.data_structures.arbor.Arbor.select_halos
    ~ytree.data_structures.arbor.Arbor.set_selector

--- a/ytree/data_structures/arbor.py
+++ b/ytree/data_structures/arbor.py
@@ -162,18 +162,29 @@ class Arbor(metaclass=RegisteredArbor):
                 new_unit, self.unit_registry.lut[my_unit][0],
                 length, self.unit_registry.lut[my_unit][3])
 
-        setup = True
+    @functools.cached_property
+    def cosmology(self):
+        """
+        Cosmology calculator with self-consistent parameters and units.
+
+        See :ref:`yt:cosmology-calculator` for more information.
+        """
+
+        missing = []
         for attr in ["hubble_constant",
                      "omega_matter",
                      "omega_lambda"]:
             if getattr(self, attr) is None:
-                setup = False
-                ytreeLogger.warning(
-                    f"{attr} missing from data. "
-                    "Arbor will have no cosmology calculator.")
+                missing.append(attr)
 
-        if setup:
-            self.cosmology = Cosmology(
+        if missing:
+            ytreeLogger.warning(
+                "Cannot create cosmology calculator without missing attributes: " +
+                str(missing))
+            return None
+
+        else:
+            return Cosmology(
                 hubble_constant=self.hubble_constant,
                 omega_matter=self.omega_matter,
                 omega_lambda=self.omega_lambda,
@@ -725,7 +736,27 @@ class Arbor(metaclass=RegisteredArbor):
     @property
     def arr(self):
         """
-        Create a unyt_array using the Arbor's unit registry.
+        Create a unyt_array using the Arbor's unit system.
+
+        Parameters
+        ----------
+
+        input_array : Iterable
+            A tuple, list, or array to attach units to
+        units: String unit specification, unit symbol or astropy object
+            The units of the array. Powers must be specified using python syntax
+            (cm**3, not cm^3).
+        dtype : string or NumPy dtype object
+            The dtype of the returned array data
+
+        Examples
+        --------
+
+        >>> import ytree
+        >>> a = ytree.load("consistent_trees/tree_0_0_0.dat")
+        >>> a.arr([1,2,3], "kg")
+        unyt_array([1, 2, 3], 'kg')
+
         """
         if self._arr is not None:
             return self._arr
@@ -737,7 +768,27 @@ class Arbor(metaclass=RegisteredArbor):
     @property
     def quan(self):
         """
-        Create a unyt_quantity using the Arbor's unit registry.
+        Create a unyt_quantity using the Arbor's unit system.
+
+        Parameters
+        ----------
+
+        input_array : Iterable
+            A tuple, list, or array to attach units to
+        units: String unit specification, unit symbol or astropy object
+            The units of the array. Powers must be specified using python syntax
+            (cm**3, not cm^3).
+        dtype : string or NumPy dtype object
+            The dtype of the returned array data
+
+        Examples
+        --------
+
+        >>> import ytree
+        >>> a = ytree.load("consistent_trees/tree_0_0_0.dat")
+        >>> a.quan(34, "cm")
+        unyt_quantity(34, 'cm')
+
         """
         if self._quan is not None:
             return self._quan

--- a/ytree/data_structures/fields.py
+++ b/ytree/data_structures/fields.py
@@ -210,9 +210,8 @@ Check the TypeError exception above for more details.
         self.arbor.add_derived_field(
             "redshift", _redshift, units="", force_add=False)
 
-        if hasattr(self.arbor, "cosmology"):
-            self.arbor.add_derived_field(
-                "time", _time, units="Myr", force_add=False)
+        self.arbor.add_derived_field(
+            "time", _time, units="Myr", force_add=False)
 
     def add_vector_field(self, fieldname):
         """

--- a/ytree/data_structures/fields.py
+++ b/ytree/data_structures/fields.py
@@ -21,6 +21,7 @@ from ytree.utilities.exceptions import \
     ArborFieldAlreadyExists, \
     ArborFieldCircularDependency, \
     ArborFieldDependencyNotFound, \
+    ArborDerivedFieldException, \
     ArborFieldNotFound
 from ytree.utilities.logger import \
     ytreeLogger as mylog
@@ -29,6 +30,9 @@ def _redshift(field, data):
     return 1. / data["scale_factor"] - 1.
 
 def _time(field, data):
+    co = data.arbor.cosmology
+    if co is None:
+        raise ArborDerivedFieldException(field["name"], data.arbor)
     return data.arbor.cosmology.t_from_z(data["redshift"])
 
 def _vector_func(field, data):
@@ -178,6 +182,8 @@ class FieldInfoContainer(dict):
         fc = FieldDetector(self.arbor, name=name)
         try:
             rv = function(info, fc)
+        except ArborDerivedFieldException:
+            return
         except TypeError as e:
             raise RuntimeError(
 """

--- a/ytree/utilities/exceptions.py
+++ b/ytree/utilities/exceptions.py
@@ -25,6 +25,11 @@ class ArborFieldException(Exception):
         self.field = field
         self.arbor = arbor
 
+class ArborDerivedFieldException(ArborFieldException):
+    def __str__(self):
+        return (f"Derived field \"{self.field}\" could not be "
+                f"generated for {self.arbor}.")
+
 class ArborFieldDependencyNotFound(Exception):
     def __init__(self, field, dependency, arbor=None):
         self.field = field


### PR DESCRIPTION
This closes issue #130. I've added documentation for the cosmology calculator as well as the arr and quan helper attributes for creating unyt arrays and quantities. I've also converted the cosmology attribute into a cached property, which has the added benefit of getting rid of the warning messages if cosmological parameters aren't available. I've also made some intersphinx references explicit to avoid confusion.