### PR TITLE
Add preprocess and handoff_attrs options to AnalysisPipeline

### DIFF
--- a/ytree/analysis/analysis_pipeline.py
+++ b/ytree/analysis/analysis_pipeline.py
@@ -142,10 +142,16 @@ class AnalysisPipeline:
 
     @parallel_root_only
     def _preprocess(self):
-        "Create output directories and do any other preliminary steps."
+        """
+        Create output directories and do any other preliminary steps.
+
+        Run any preprocess functions associated with operation functions.
+        """
 
         if self._preprocessed:
             return
+
+        pre_run = []
 
         for action in self.actions:
             my_output_dir = action.kwargs.get("output_dir")
@@ -153,6 +159,11 @@ class AnalysisPipeline:
                 new_output_dir = ensure_dir(
                     os.path.join(self.output_dir, my_output_dir))
                 action.kwargs["output_dir"] = new_output_dir
+
+            pre_func = getattr(action.function, "preprocess", None)
+            if pre_func is not None and pre_func not in pre_run:
+                pre_func()
+                pre_run.append(pre_func)
 
         self._preprocessed = True
 


### PR DESCRIPTION
This adds two somewhat niche options to the AnalysisPipeline that I made use of in [yt_p2p](https://github.com/brittonsmith/yt_p2p) for [Smith et al. (2024)](https://ui.adsabs.harvard.edu/abs/2024MNRAS.532.3797S).
1. Add `handoff_attrs` keyword to `process_target` function. This allows one to specify a set of attributes to hand between TreeNodes during the iteration of the analysis pipeline. For instance, I used this to load a yt dataset and pass a pointer to it from node to node so that it didn't need to be reloaded and have the index rebuilt.
2. Add ability to provide a preprocess function to analysis pipeline actions. When creating an analysis function, one can attach to it a preprocess function to be run once when the AnalysisPipeline is first setup. For example, this could be used to create storage directories. I used it to modify ytree classes to add additional properties to them.

These will obviously need some docs.