### PR TITLE
Minor speedup for get_node

### DIFF
--- a/ytree/data_structures/tree_node.py
+++ b/ytree/data_structures/tree_node.py
@@ -361,6 +361,9 @@ class TreeNode:
 
         """
 
+        if index == 0:
+            return self
+
         self.arbor._setup_tree(self)
         self.arbor._grow_tree(self)
         indices = getattr(self, f"_{selector}_field_indices", None)

--- a/ytree/data_structures/tree_node.py
+++ b/ytree/data_structures/tree_node.py
@@ -335,7 +335,13 @@ class TreeNode:
         Get a single TreeNode from a tree.
 
         Use this to get the nth TreeNode from a forest, tree, or
-        progenitor list for which the calling TreeNode is the head.
+        progenitor list.
+
+        For forest selection, the index value is absolute and refers
+        to the entire forest in which the node belongs.
+
+        For tree and prog selection, the index refers to the tree
+        for which the calling TreeNode is the head.
 
         Parameters
         ----------
@@ -361,7 +367,7 @@ class TreeNode:
 
         """
 
-        if index == 0:
+        if selector in ("tree", "prog") and index == 0:
             return self
 
         self.arbor._setup_tree(self)


### PR DESCRIPTION
Another small gem from the p2p branch. This is a minor speedup for `get_node`. When I implemented it originally, I forgot that we shouldn't do this if using forest selection since that uses an absolute index. I fixed it by only doing this for forest and progenitor selection.