### PR TITLE
Add testing option to exclude slow tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -255,7 +255,7 @@ workflows:
            name: "Python 3.9 tests"
            tag: "3.9.20"
            ytdev: 0
-           pytestkwargs: "--serialonly"
+           pytestkwargs: "--exclude-parallel --exclude-slow"
 
        - tests:
            requires:
@@ -264,7 +264,7 @@ workflows:
            tag: "3.12.7"
            coverage: 1
            ytdev: 1
-           pytestkwargs: "--serialonly"
+           pytestkwargs: "--exclude-parallel --exclude-slow"
 
        - tests:
            requires:
@@ -273,7 +273,7 @@ workflows:
            tag: "3.12.7"
            coverage: 0
            ytdev: 0
-           pytestkwargs: "--serialonly"
+           pytestkwargs: "--exclude-parallel --exclude-slow"
 
        - docs-test:
            name: "Test docs build"
@@ -293,14 +293,14 @@ workflows:
            name: "Python 3.9 tests"
            tag: "3.9.20"
            ytdev: 0
-           pytestkwargs: "--serialonly"
+           pytestkwargs: "--exclude-parallel --exclude-slow"
 
        - tests:
            name: "Python 3.12 tests"
            tag: "3.12.7"
            coverage: 0
            ytdev: 1
-           pytestkwargs: "--serialonly"
+           pytestkwargs: "--exclude-parallel --exclude-slow"
 
        - docs-test:
            name: "Test docs build"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,12 +3,16 @@ import pytest
 
 def pytest_addoption(parser):
     parser.addoption(
-        "--parallelonly", action="store_true", default=False,
-        help="run only parallel tests"
+        "--exclude-slow", action="store_true", default=False,
+        help="exclude tests marked as slow"
     )
     parser.addoption(
-        "--serialonly", action="store_true", default=False,
-        help="run only serial tests"
+        "--exclude-serial", action="store_true", default=False,
+        help="exclude tests not using parallelism"
+    )
+    parser.addoption(
+        "--exclude-parallel", action="store_true", default=False,
+        help="exclude tests using parallelism"
     )
 
 
@@ -17,14 +21,22 @@ def pytest_configure(config):
 
 
 def pytest_collection_modifyitems(config, items):
-    if config.getoption("--parallelonly"):
-        skip_serial = pytest.mark.skip(reason="only running parallel tests")
+    if config.getoption("--exclude-slow"):
+        skip_slow = pytest.mark.skip(reason="excluding tests marked as slow")
+        for item in items:
+            if getattr(item, "cls", None) is None:
+                continue
+            if getattr(item.cls, "slow", False):
+                item.add_marker(skip_slow)
+
+    if config.getoption("--exclude-serial"):
+        skip_serial = pytest.mark.skip(reason="excluding tests not using parallelism")
         for item in items:
             if "parallel" not in item.keywords:
                 item.add_marker(skip_serial)
 
-    if config.getoption("--serialonly"):
-        skip_parallel = pytest.mark.skip(reason="only running serial tests")
+    if config.getoption("--exclude-parallel"):
+        skip_parallel = pytest.mark.skip(reason="excluding tests using parallelism")
         for item in items:
             if "parallel" in item.keywords:
                 item.add_marker(skip_parallel)

--- a/tests/frontends/test_ahf_2.py
+++ b/tests/frontends/test_ahf_2.py
@@ -9,3 +9,4 @@ class AHFCRMArborTest(TempDirTest, ArborTest):
     test_filename = "AHF_100_tiny/GIZMO-NewMDCLUSTER_0047.snap_128.parameter"
     num_data_files = 5
     tree_skip = 100
+    slow = True

--- a/ytree/utilities/testing.py
+++ b/ytree/utilities/testing.py
@@ -195,6 +195,7 @@ class ArborTest:
     num_data_files = None
     tree_skip = 1
     custom_vector_fields = None
+    slow = False
 
     _arbor = None
     @property


### PR DESCRIPTION
This adds an option to exclude tests marked as "slow". This should hopefully prevent tests on circleci from timing out.