### PR TITLE
Fix ruff lint errors

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -13,8 +13,6 @@
 # serve to show the default.
 
 import glob
-import os
-import sys
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/doc/source/examples/halo_age.py
+++ b/doc/source/examples/halo_age.py
@@ -19,10 +19,10 @@ tabbing (i.e., 4 spaces to the left).
 
 """
 
+import ytree
 import numpy as np
 import yt
 yt.enable_parallelism()
-import ytree
 
 def calc_a50(node):
     # main progenitor masses

--- a/doc/source/examples/halo_significance.py
+++ b/doc/source/examples/halo_significance.py
@@ -17,9 +17,9 @@ tabbing (i.e., 4 spaces to the left).
 
 """
 
+import ytree
 import yt
 yt.enable_parallelism()
-import ytree
 
 def calc_significance(node):
    if node.descendent is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,15 @@ Changelog = "https://ytree.readthedocs.io/en/latest/Changelog.html"
 Repository = "https://github.com/ytree-project/ytree"
 Issues = "https://github.com/ytree-project/ytree/issues"
 
+[tool.ruff.lint]
+# By default, Ruff enables Flake8's F rules, along with a subset of the E rules,
+# omitting any stylistic rules that overlap with the use of a formatter, like
+# ruff format
+select = ["E4", "E7", "E9", "F"]
+exclude = [
+    "*/__init__.py"
+]
+
 [tool.setuptools]
 include-package-data = true
 zip-safe = false

--- a/tests/parallel/parallel_nodes.py
+++ b/tests/parallel/parallel_nodes.py
@@ -13,12 +13,12 @@ parallel_nodes test script
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
+import ytree
+from ytree.utilities.testing import get_tree_split
 from mpi4py import MPI
 import sys
 import yt
 yt.enable_parallelism()
-from ytree.utilities.testing import get_tree_split
-import ytree
 
 def run():
     input_fn, output_fn, selection, group = sys.argv[1:5]

--- a/tests/parallel/parallel_tree_nodes.py
+++ b/tests/parallel/parallel_tree_nodes.py
@@ -13,12 +13,12 @@ parallel_tree_nodes test script
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
+import ytree
 from mpi4py import MPI
 import numpy as np
 import sys
 import yt
 yt.enable_parallelism()
-import ytree
 
 def run():
     input_fn, output_fn, selection, group = sys.argv[1:5]

--- a/tests/parallel/parallel_trees.py
+++ b/tests/parallel/parallel_trees.py
@@ -13,12 +13,12 @@ parallel_trees test script
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
+import ytree
+from ytree.utilities.testing import get_tree_split
 from mpi4py import MPI
 import sys
 import yt
 yt.enable_parallelism()
-from ytree.utilities.testing import get_tree_split
-import ytree
 
 def run():
     input_fn, output_fn, selection, group = sys.argv[1:5]

--- a/ytree/data_structures/arbor.py
+++ b/ytree/data_structures/arbor.py
@@ -576,7 +576,7 @@ class Arbor(metaclass=RegisteredArbor):
 
         # If we've been given an array of TreeNodes,
         # just yield them back.
-        if getattr(indices, 'dtype', None) == object:
+        if getattr(indices, 'dtype', None) is object:
             for index in indices:
                 yield index
             return

--- a/ytree/data_structures/tree_node_selector.py
+++ b/ytree/data_structures/tree_node_selector.py
@@ -76,9 +76,11 @@ class TreeNodeSelector:
     def __init__(self, function, args=None, kwargs=None):
         self.function = function
         self.args = args
-        if self.args is None: self.args = []
+        if self.args is None:
+            self.args = []
         self.kwargs = kwargs
-        if self.kwargs is None: self.kwargs = {}
+        if self.kwargs is None:
+            self.kwargs = {}
 
     def __call__(self, ancestors):
         return self.function(ancestors, *self.args, **self.kwargs)

--- a/ytree/frontends/consistent_trees/arbor.py
+++ b/ytree/frontends/consistent_trees/arbor.py
@@ -85,7 +85,8 @@ class ConsistentTreesArbor(SegmentedArbor):
                           block_size).astype(np.int64)
         for ib in range(nblocks):
             my_block = min(block_size, file_size - offset)
-            if my_block <= 0: break
+            if my_block <= 0:
+                break
             buff = data_file.fh.read(my_block)
             lihash = -1
             for ih in range(buff.count("#")):
@@ -115,7 +116,8 @@ class ConsistentTreesArbor(SegmentedArbor):
         with the string, "Consistent Trees".
         """
         fn = args[0]
-        if not fn.endswith(".dat"): return False
+        if not fn.endswith(".dat"):
+            return False
         with open(fn, "r") as f:
             valid = False
             while True:
@@ -125,7 +127,8 @@ class ConsistentTreesArbor(SegmentedArbor):
                 if "Consistent Trees" in line:
                     valid = True
                     break
-            if not valid: return False
+            if not valid:
+                return False
         return True
 
 class ConsistentTreesGroupArbor(ConsistentTreesArbor):

--- a/ytree/frontends/consistent_trees/io.py
+++ b/ytree/frontends/consistent_trees/io.py
@@ -65,7 +65,8 @@ class ConsistentTreesTreeFieldIO(TreeFieldIO):
 
         for i, datum in enumerate(data):
             ldata = datum.strip().split()
-            if len(ldata) == 0: continue
+            if len(ldata) == 0:
+                continue
             for field in fields:
                 dtype = my_dtypes[field]
                 field_data[field][i] = dtype(ldata[fi[field]["column"]])

--- a/ytree/frontends/rockstar/arbor.py
+++ b/ytree/frontends/rockstar/arbor.py
@@ -66,7 +66,8 @@ class RockstarArbor(CatalogArbor):
                 self.box_size = self.quan(float(pars[0]), pars[1])
             # Looking for <quantities> in <units>
             elif line.startswith("#Units:"):
-                if " in " not in line: continue
+                if " in " not in line:
+                    continue
                 quan, punits = line[8:].strip().split(" in ", 2)
                 for rem in rems:
                     while rem in punits:

--- a/ytree/utilities/io.py
+++ b/ytree/utilities/io.py
@@ -93,7 +93,8 @@ def _hdf5_yt_array_lite(fh, field):
     units = ""
     if "units" in fh[field].attrs:
         units = fh[field].attrs["units"]
-    if units == "dimensionless": units = ""
+    if units == "dimensionless":
+        units = ""
     return (fh[field][()], units)
 
 def f_text_block(f, block_size=4096, file_size=None, sep="\n",
@@ -118,7 +119,8 @@ def f_text_block(f, block_size=4096, file_size=None, sep="\n",
     for ib in range(nblocks):
         offset = f.tell()
         my_block = min(block_size, read_size-offset)
-        if my_block <= 0: break
+        if my_block <= 0:
+            break
         buff = f.read(my_block)
         linl = -1
         for ih in range(buff.count(sep)):

--- a/ytree/utilities/logger.py
+++ b/ytree/utilities/logger.py
@@ -34,7 +34,8 @@ ytreeLogger.setLevel(20)
 ytreeLogger.propagate = False
 
 def set_parallel_logger(comm):
-    if comm.size == 1: return
+    if comm.size == 1:
+        return
     f = logging.Formatter(f"P{comm.rank:03d} {ufstring}")
     if len(ytreeLogger.handlers) > 0:
         ytreeLogger.handlers[0].setFormatter(f)

--- a/ytree/yt_frontend/data_structures.py
+++ b/ytree/yt_frontend/data_structures.py
@@ -219,7 +219,8 @@ class YTreeDataset(SavedDataset):
 
     @classmethod
     def _is_valid(self, *args, **kwargs):
-        if not args[0].endswith(".h5"): return False
+        if not args[0].endswith(".h5"):
+            return False
         with h5py.File(args[0], "r") as f:
             if "data_type" in f.attrs and "arbor_type" in f.attrs:
                 return True


### PR DESCRIPTION
This is the first step of ruff formatting the code. First, we'll just fix all the lint errors.