### PR TITLE
Refactor to versioning and citation information

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ pip install ytree
 ### conda installation
 
 ```
-conda install -c conda-forge ytree
+conda install conda-forge::ytree
 ```
 
 ### source installation
@@ -100,50 +100,8 @@ Sample data for all merger tree formats supported by `ytree` is available on the
 
 ## Citing `ytree`
 
-If you use `ytree` in your work, please cite the following:
-
-```
-Smith et al., (2019). ytree: A Python package for analyzing merger trees.
-Journal of Open Source Software, 4(44), 1881,
-https://doi.org/10.21105/joss.01881
-```
-
-For BibTeX users:
-
-```
-  @article{ytree,
-    doi = {10.21105/joss.01881},
-    url = {https://doi.org/10.21105/joss.01881},
-    year  = {2019},
-    month = {dec},
-    publisher = {The Open Journal},
-    volume = {4},
-    number = {44},
-    pages = {1881},
-    author = {Britton D. Smith and Meagan Lang},
-    title = {ytree: A Python package for analyzing merger trees},
-    journal = {Journal of Open Source Software}
-  }
-```
-
-If you would like to also cite the specific version of `ytree` used in
-your work, include the following reference:
-
-```
-  @software{britton_smith_2025_17045610,
-    author       = {Britton Smith and
-                    Meagan Lang and
-                    John Wise and
-                    Juanjo Bazán},
-    title        = {ytree-project/ytree: ytree 3.3.1 Release},
-    month        = sep,
-    year         = 2025,
-    publisher    = {Zenodo},
-    version      = {ytree-3.3.1},
-    doi          = {10.5281/zenodo.17045610},
-    url          = {https://doi.org/10.5281/zenodo.17045610},
-  }
-```
+If you use `ytree` in your work, please cite it. Citation instructions
+can be found [here](https://ytree.readthedocs.io/en/latest/Citing.html).
 
 ## Resources
 

--- a/doc/source/Installation.rst
+++ b/doc/source/Installation.rst
@@ -21,7 +21,7 @@ conda
 
 .. code-block:: bash
 
-   $ conda install -c conda-forge ytree
+   $ conda install conda-forge::ytree
 
 Installing from Source
 ----------------------

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -13,11 +13,17 @@
 # serve to show the default.
 
 import glob
+import os
+import sys
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 # sys.path.insert(0, os.path.abspath('.'))
+
+sys.path.insert(0, os.path.abspath("../../scripts"))
+
+from get_version import get_version
 
 # -- General configuration ------------------------------------------------
 
@@ -67,7 +73,7 @@ author = "ytree development team"
 # built documents.
 #
 # The short X.Y version.
-version = "3.3.2.dev"
+version = get_version()
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/scripts/get_version.py
+++ b/scripts/get_version.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+import os
+import re
+
+
+def get_version():
+    fn = os.path.join(os.path.dirname(__file__), "..", "ytree", "__init__.py")
+    lines = open(fn, mode="r").readlines()
+    for line in lines:
+        match = re.search(r"__version__\s+=\s+\"(.+)\"", line)
+        if match:
+            version = match.groups()[0]
+            return version
+
+
+if __name__ == "__main__":
+    print(get_version())

--- a/ytree/__init__.py
+++ b/ytree/__init__.py
@@ -23,4 +23,4 @@ from ytree.visualization.tree_plot import TreePlot
 
 from ytree.utilities.parallel import parallel_trees, parallel_tree_nodes, parallel_nodes
 
-__version__ = "3.3.2.dev"
+__version__ = "3.3.2-dev"


### PR DESCRIPTION
This implements a function to scrape `ytree/__init__.py` to get the current version so we only have one place to update. I also changed the README to point to the docs for citation information for the same reason.