### PR TITLE
Update python versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,27 +227,27 @@ workflows:
      jobs:
        - tests:
            name: "Python 3.9 tests"
-           tag: "3.9.20"
+           tag: "3.9.22"
            ytdev: 0
            pytestkwargs: "--exclude-slow"
 
        - tests:
-           name: "Python 3.12 tests"
-           tag: "3.12.7"
+           name: "Python 3.13 tests"
+           tag: "3.13.7"
            coverage: 1
            ytdev: 1
            pytestkwargs: "--exclude-slow"
 
        - tests:
-           name: "Python 3.12 tests"
-           tag: "3.12.7"
+           name: "Python 3.13 tests"
+           tag: "3.13.7"
            coverage: 0
            ytdev: 0
            pytestkwargs: "--exclude-slow"
 
        - docs-test:
            name: "Test docs build"
-           tag: "3.12.7"
+           tag: "3.13.7"
            ytdev: 0
 
    weekly:
@@ -261,18 +261,18 @@ workflows:
      jobs:
        - tests:
            name: "Python 3.9 tests"
-           tag: "3.9.20"
+           tag: "3.9.22"
            ytdev: 0
            pytestkwargs: "--exclude-slow"
 
        - tests:
-           name: "Python 3.12 tests"
-           tag: "3.12.7"
+           name: "Python 3.13 tests"
+           tag: "3.13.7"
            coverage: 0
            ytdev: 1
            pytestkwargs: "--exclude-slow"
 
        - docs-test:
            name: "Test docs build"
-           tag: "3.12.7"
+           tag: "3.13.7"
            ytdev: 0

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![codecov](https://codecov.io/gh/ytree-project/ytree/branch/main/graph/badge.svg)](https://codecov.io/gh/ytree-project/ytree)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/ytree-project/ytree/main.svg)](https://results.pre-commit.ci/latest/github/ytree-project/ytree/main)
 [![Documentation Status](https://readthedocs.org/projects/ytree/badge/?version=latest)](http://ytree.readthedocs.io/en/latest/?badge=latest)
+[![Supported Python Versions](https://img.shields.io/pypi/pyversions/ytree)](https://pypi.org/project/ytree/)
 [![PyPI version](https://badge.fury.io/py/ytree.svg)](https://badge.fury.io/py/ytree)
 [![Anaconda-Server Badge](https://anaconda.org/conda-forge/ytree/badges/version.svg)](https://anaconda.org/conda-forge/ytree)
 [![DOI](https://joss.theoj.org/papers/10.21105/joss.01881/status.svg)](https://doi.org/10.21105/joss.01881)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 requires-python = ">=3.9"
 dependencies = [


### PR DESCRIPTION
This updates the circleci python versions used for testing, including adding a python 3.13. If it works, we will include that as a supported version and add a badge for it.